### PR TITLE
Show question attempts in CAT context table

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -405,9 +405,17 @@ class catquiz {
         $params = [];
         $where = [];
         $filter = '';
-
-        $select = "*";
-        $from = "{local_catquiz_catcontext}";
+        $select = "ccc.*, s1.attempts";
+        $from = "{local_catquiz_catcontext} ccc
+                 LEFT JOIN (
+                        SELECT ccc1.id, COUNT(*) AS attempts
+                          FROM {local_catquiz_catcontext} ccc1
+                          JOIN {question_attempt_steps} qas
+                            ON ccc1.starttimestamp < qas.timecreated AND ccc1.endtimestamp > qas.timecreated
+                           AND qas.fraction IS NOT NULL
+                      GROUP BY ccc1.id
+                 ) s1
+                 ON s1.id = ccc.id";
         $where = "1=1";
 
         return [$select, $from, $where, $filter, $params];

--- a/classes/output/catcontextdashboard.php
+++ b/classes/output/catcontextdashboard.php
@@ -69,7 +69,7 @@ class catcontextdashboard implements renderable, templatable {
             'endtimestamp' => get_string('endtimestamp', 'local_catquiz'),
             'timecreated' => get_string('timecreated'),
             'timemodified' => get_string('timemodified', 'local_catquiz'),
-            'numberofquestions' => get_string('numberofquestions', 'local_catquiz'),
+            'attempts' => get_string('attempts', 'local_catquiz'),
             'action' => get_string('action', 'local_catquiz'),
         ];
 

--- a/classes/table/catcontext_table.php
+++ b/classes/table/catcontext_table.php
@@ -105,9 +105,11 @@ class catcontext_table extends wunderbyte_table {
         return $values->testitems;
     }
 
-    public function col_numberofquestions($values) {
-
-        return 'xy';
+    public function col_attempts($values) {
+        if  (!empty($values->attempts)) {
+            return $values->attempts;
+        }
+        return '0';
     }
 
     /**

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -91,6 +91,7 @@ $string['starttimestamp'] = 'Kontext Startzeit';
 $string['endtimestamp'] = 'Kontext Endzeit';
 $string['timemodified'] = 'Zuletzt geändert';
 $string['notimelimit'] = 'No time limit';
+$string['attempts'] = 'Versuche';
 $string['action'] = 'Action';
 $string['starttimestamp'] = 'Zeitraum Anfang';
 $string['endtimestamp'] = 'Zeitraum Ende';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -90,6 +90,7 @@ $string['starttimestamp'] = 'Context start time';
 $string['endtimestamp'] = 'Context end time';
 $string['timemodified'] = 'Time modified';
 $string['notimelimit'] = 'Kein Zeitlimit';
+$string['attempts'] = 'Attempts';
 $string['action'] = 'Aktion';
 
 $string['starttimestamp'] = 'Starttime';


### PR DESCRIPTION
With this change, the context table shows for each context the number of question attempts. This number is defined as the number of all question attempt steps that fall within the timespan defined by the context and have a fraction that is not null.