### PR TITLE
Revert adding model data to item table

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -140,8 +140,8 @@ class catquiz {
         }
 
         $select = ' DISTINCT *';
-        $from = "(SELECT COALESCE(s3.id, q.id) as id,
-                    q.id as qid,
+        $from = "(SELECT
+                    q.id,
                     qbe.idnumber,
                     q.name,
                     q.questiontext,
@@ -149,10 +149,7 @@ class catquiz {
                     qc.name as categoryname,
                     lci.catscaleid catscaleid,
                     lci.componentname component,
-                    s2.attempts,
-                    s3.model,
-                    s3.difficulty,
-                    s3.status
+                    s2.attempts
                 FROM {question} q
                 JOIN {question_versions} qv
                     ON q.id=qv.questionid
@@ -173,11 +170,6 @@ class catquiz {
                     WHERE ccc1.id = :contextid
                     GROUP BY ccc1.id, qa.questionid
                 ) s2 ON q.id = s2.questionid
-                LEFT JOIN (
-                    SELECT lcip.id, lcip.componentid, lcip.componentname, lcip.model, lcip.difficulty, lcip.status
-                    FROM {local_catquiz_itemparams} lcip
-                    WHERE lcip.contextid = :contextid2
-                ) s3 ON s3.componentid = q.id AND s3.componentname='question'
             ) as s1";
 
         $where = ' catscaleid = :catscaleid ';

--- a/classes/output/catscaledashboard.php
+++ b/classes/output/catscaledashboard.php
@@ -190,27 +190,19 @@ class catscaledashboard implements renderable, templatable {
         $table->set_filter_sql($select, $from, $where, $filter, $params);
 
         $table->define_columns([
-            'qid',
             'idnumber',
             'questiontext',
             'qtype',
             'categoryname',
             'attempts',
-            'model',
-            'difficulty',
-            'status',
             'action'
         ]);
         $table->define_headers([
-            get_string('questionid', 'local_catquiz'),
             get_string('label', 'local_catquiz'),
             get_string('questiontext', 'local_catquiz'),
             get_string('questiontype', 'local_catquiz'),
             get_string('questioncategories', 'local_catquiz'),
             get_string('questioncontextattempts', 'local_catquiz'),
-            get_string('model', 'local_catquiz'),
-            get_string('itemdifficulty', 'local_catquiz'),
-            get_string('status', 'local_catquiz'),
             get_string('action', 'local_catquiz'),
         ]);
 
@@ -229,14 +221,12 @@ class catscaledashboard implements renderable, templatable {
         ]]);
         $table->define_fulltextsearchcolumns(['idnumber', 'name', 'questiontext', 'qtype']);
         $table->define_sortablecolumns([
-            'qid',
+            'id',
             'idnumber',
             'name',
             'questiontext',
             'qtype',
             'attempts',
-            'model',
-            'difficulty'
         ]);
 
         $table->tabletemplate = 'local_wunderbyte_table/twtable_list';

--- a/classes/table/testitems_table.php
+++ b/classes/table/testitems_table.php
@@ -28,7 +28,6 @@ use context_system;
 use Exception;
 use html_writer;
 use local_catquiz\catscale;
-use local_catquiz\local\model\model_item_param;
 use local_wunderbyte_table\output\table;
 use local_wunderbyte_table\wunderbyte_table;
 use mod_booking\booking;
@@ -120,84 +119,12 @@ class testitems_table extends wunderbyte_table {
     public function col_questioncontextattempts($values) {
         return $values->questioncontextattempts;
     }
-
-    public function col_status($values) {
-        global $OUTPUT;
-
-        // No need to display checkboxes if there are no item params for this
-        // item
-        if (empty($values->model)) {
-            return;
-        }
-
-        $outputstring = '';
-
-        switch ($values->status) {
-            case 0:
-                $outputstring = get_string('notselected', 'local_catquiz');
-                break;
-            case 1:
-                $outputstring = get_string('selected', 'local_catquiz');
-                break;
-            case 5:
-                $outputstring = get_string('manuallyselected', 'local_catquiz');
-                break;
-            case -1:
-                $outputstring = get_string('problematic', 'local_catquiz');
-                break;
-            case -5:
-                $outputstring = get_string('manuallyexcluded', 'local_catquiz');
-                break;
-        }
-
-        $data['showactionbuttons'][] = [
-            'label' => get_string('excluded', 'local_catquiz'), // Name of your action button.
-            'id' => $values->id,
-            'name' => $this->uniqueid.'-'.$values->id,
-            'methodname' => 'update_item_status', // The method needs to be added to your child of wunderbyte_table class.
-            'ischeckbox' => true,
-            'checked' => $values->status == model_item_param::STATUS_EXCLUDE,
-            'data' => [ // Will be added eg as data-id = $values->id, so values can be transmitted to the method above.
-                'id' => $values->id,
-                'componentid' => $values->qid,
-                'status' => model_item_param::STATUS_EXCLUDE,
-                'model' => $values->model,
-                'labelcolumn' => 'username',
-            ]
-        ];
-
-        $data['showactionbuttons'][] = [
-            'label' => get_string('included', 'local_catquiz'), // Name of your action button.
-            'id' => $values->id,
-            'name' => $this->uniqueid.'-'.$values->id,
-            'methodname' => 'update_item_status', // The method needs to be added to your child of wunderbyte_table class.
-            'ischeckbox' => true,
-            'checked' => $values->status == model_item_param::STATUS_SET_MANUALLY,
-            'data' => [ // Will be added eg as data-id = $values->id, so values can be transmitted to the method above.
-                'id' => $values->id,
-                'componentid' => $values->qid,
-                'status' => model_item_param::STATUS_SET_MANUALLY,
-                'model' => $values->model,
-                'labelcolumn' => 'username',
-            ]
-        ];
-
-        // This transforms the array to make it easier to use in mustache template.
-        table::transform_actionbuttons_array($data['showactionbuttons']);
-
-        return $outputstring . $OUTPUT->render_from_template('local_wunderbyte_table/component_actionbutton', $data);
-
-
-    }
     public function col_action($values) {
-        if (!property_exists($values, 'qid')) {
-            return;
-        }
 
         global $OUTPUT;
 
         $url = new moodle_url('/local/catquiz/edit_testitem.php', [
-            'id' => $values->qid,
+            'id' => $values->id,
             'catscaleid' => $this->catscaleid ?? 0,
             'component' => $values->component,
             'contextid' => $this->contextid,

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -175,10 +175,6 @@ $string['questiontext'] = "Fragentext";
 $string['testitemdashboard'] = "Testitem Dashboard";
 $string['itemdifficulty'] = "Item difficulty";
 $string['likelihood'] = "Likelihood";
-$string['status'] = 'Status';
-$string['included'] = "Included";
-$string['excluded'] = "Excluded";
-$string['questionid'] = "Frage ID";
 
 $string['difficulty'] = "Schwierigkeit";
 $string['discrimination'] = "Diskriminierung";

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -180,10 +180,6 @@ $string['questiontext'] = "Question text";
 $string['testitemdashboard'] = "Testitem Dashboard";
 $string['itemdifficulty'] = "Item difficulty";
 $string['likelihood'] = "Likelihood";
-$string['status'] = 'Status';
-$string['included'] = "Included";
-$string['excluded'] = "Excluded";
-$string['questionid'] = "Question ID";
 
 $string['difficulty'] = "Difficulty";
 $string['discrimination'] = "Discrimination";


### PR DESCRIPTION
This removes the model difficulty and status from the items tables, so that there is only one row per item. Before that, we had one row per model per item.