### PR TITLE
Update raschbirnbaum models

### DIFF
--- a/catmodel/raschbirnbauma/classes/raschbirnbauma.php
+++ b/catmodel/raschbirnbauma/classes/raschbirnbauma.php
@@ -106,7 +106,7 @@ class raschbirnbauma extends model_raschmodel {
         $a = $ip['difficulty'];
         
         if ($k < 1.0) {
-            return 1 / (1 + exp($pp - $a));
+            return 1 - self::likelihood($pp, $ip, 1.0);
         } else {
             return 1 / (1 + exp($a - $pp));
         }

--- a/catmodel/raschbirnbauma/classes/raschbirnbauma.php
+++ b/catmodel/raschbirnbauma/classes/raschbirnbauma.php
@@ -224,12 +224,12 @@ class raschbirnbauma extends model_raschmodel {
      *
      * @param array<float> $pp - person ability parameter ('ability')
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
-     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $frac - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return float - weighted residuals
      */
-   function least_mean_squares(array $pp, array $ip, float $k, float $n):float{
-        return $n * ($k - likelihood($pp, $ip, 1.0)) ** 2;
+   function least_mean_squares(array $pp, array $ip, float $frac, float $n):float{
+        return $n * ($frac - likelihood($pp, $ip, 1.0)) ** 2;
     }
 
     /**
@@ -237,11 +237,11 @@ class raschbirnbauma extends model_raschmodel {
      *
      * @param array<float> $pp - person ability parameter ('ability')
      * @param array<float> $ip - item parameters ('difficulty')
-     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $frac - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return array - 1st derivative of lms with respect to $ip
      */
-   function least_mean_squares_1st_derivative_ip(array $pp, array $ip, float $k, float $n):array{
+   function least_mean_squares_1st_derivative_ip(array $pp, array $ip, float $frac, float $n):array{
         $pp = $pp['ability'];
         $a = $ip['difficulty'];
 
@@ -250,7 +250,7 @@ class raschbirnbauma extends model_raschmodel {
         // Pre-Calculate high frequently used exp-terms.
         $exp_ap0 = exp($a - $pp);
         
-        $derivative[0] = $n * (2 * $exp_ap0 * ($k - 1 + $exp_ap0 * $k)) / (1 + $exp_ap0) ** 3; // Calculate d/da.            
+        $derivative[0] = $n * (2 * $exp_ap0 * ($frac - 1 + $exp_ap0 * $frac)) / (1 + $exp_ap0) ** 3; // Calculate d/da.            
 
         return $derivative;
     }
@@ -260,11 +260,11 @@ class raschbirnbauma extends model_raschmodel {
      *
      * @param array<float> $pp - person ability parameter ('ability')
      * @param array<float> $ip - item parameters ('difficulty')
-     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $frac - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return array - 2nd derivative of lms with respect to $ip
      */ 
-   function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, float $k, float $n):array{
+   function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, float $frac, float $n):array{
         $pp = $pp['ability'];
         $a = $ip['difficulty'];
 
@@ -276,7 +276,7 @@ class raschbirnbauma extends model_raschmodel {
         $exp_a = exp($a);
         $exp_p = exp($pp):
         
-        $derivative[0][0]  = $n * (2 * $b ** 2 * ($exp_a * $exp_p) * (-$exp_p ** 2 + 2 * ($exp_a * $exp_p) + (-$exp_a ** 2 + $exp_p ** 2) * $k)) / ($exp_a + $exp_p) ** 4; // Calculate d²2/da². 
+        $derivative[0][0]  = $n * (2 * ($exp_a * $exp_p) * (-$exp_p ** 2 + 2 * ($exp_a * $exp_p) + (-$exp_a ** 2 + $exp_p ** 2) * $frac)) / ($exp_a + $exp_p) ** 4; // Calculate d²2/da². 
               
         return $derivative;
     }

--- a/catmodel/raschbirnbauma/classes/raschbirnbauma.php
+++ b/catmodel/raschbirnbauma/classes/raschbirnbauma.php
@@ -348,7 +348,7 @@ class raschbirnbauma extends model_raschmodel {
      * @return float
      */
 
-    public static function fisher_info(float $pp, array $ip) {
+    public static function fisher_info(array $pp, array $ip) {
         return (self::likelihood($pp, $ip, 0) * self::likelihood($pp, $ip, 1.0));
     }
 

--- a/catmodel/raschbirnbauma/classes/raschbirnbauma.php
+++ b/catmodel/raschbirnbauma/classes/raschbirnbauma.php
@@ -96,8 +96,8 @@ class raschbirnbauma extends model_raschmodel {
     /**
      * Calculates the Likelihood for a given the person ability parameter
      *
-     * @param array <float> $pp - person ability parameter ('ability')
-     * @param array <float> $ip - item parameters ('difficulty')
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
      * @param float $k - answer category (0 or 1.0)
      * @return float
      */
@@ -117,8 +117,8 @@ class raschbirnbauma extends model_raschmodel {
     /**
      * Calculates the LOG Likelihood for a given the person ability parameter
      *
-     * @param array <float> $pp - person ability parameter ('ability')
-     * @param array $ip - item parameters ('difficulty')
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
      * @param float $k - answer category (0 or 1.0)
      * @return float - log likelihood
      */
@@ -129,7 +129,8 @@ class raschbirnbauma extends model_raschmodel {
     /**
      * Calculates the 1st derivative of the LOG Likelihood with respect to the item parameters
      *
-     * @param float $pp - person ability parameter
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
      * @param float $k - answer category (0 or 1.0)
      * @return float - 1st derivative of log likelihood with respect to $pp
      */

--- a/catmodel/raschbirnbauma/classes/raschbirnbauma.php
+++ b/catmodel/raschbirnbauma/classes/raschbirnbauma.php
@@ -96,152 +96,258 @@ class raschbirnbauma extends model_raschmodel {
     /**
      * Calculates the Likelihood for a given the person ability parameter
      *
-     * @param float $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty')
+     * @param array <float> $pp - person ability parameter ('ability')
+     * @param array <float> $ip - item parameters ('difficulty')
      * @param float $k - answer category (0 or 1.0)
      * @return float
-     *
      */
-    public static function likelihood($pp, array $ip, float $k): float {
+    public static function likelihood(array $pp, array $ip, float $k): float {
+        $pp = $pp['ability'];
         $a = $ip['difficulty'];
+        
         if ($k < 1.0) {
             return 1 / (1 + exp($pp - $a));
         } else {
             return 1 / (1 + exp($a - $pp));
         }
     }
+    
     // Calculate the LOG Likelihood and its derivatives.
 
     /**
      * Calculates the LOG Likelihood for a given the person ability parameter
      *
-     * @param float $pp - person ability parameter
+     * @param array <float> $pp - person ability parameter ('ability')
      * @param array $ip - item parameters ('difficulty')
      * @param float $k - answer category (0 or 1.0)
-     * @return float
+     * @return float - log likelihood
      */
-    public static function log_likelihood($pp, array $ip, float $k): float {
+    public static function log_likelihood(array $pp, array $ip, float $k): float {
         return log(self::likelihood($pp, $ip, $k));
     }
 
+    /**
+     * Calculates the 1st derivative of the LOG Likelihood with respect to the item parameters
+     *
+     * @param float $pp - person ability parameter
+     * @param float $k - answer category (0 or 1.0)
+     * @return float - 1st derivative of log likelihood with respect to $pp
+     */
     public static function log_likelihood_p(array $pp, array $ip, float $k): float {
-        $pp = $pp[0];
+        $pp = $pp['ability'];
         $a = $ip['difficulty'];
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_a = exp($a);
+        $exp_p = exp($pp);
+        
         if ($k < 1.0) {
-            return -exp($pp) / (exp($a) + exp($pp));
+            return -$exp_p / ($exp_a + $exp_p);
         } else {
-            return exp($a) / (exp($a) + exp($pp));
+            return $exp_a / ($exp_a + $exp_p);
         }
     }
 
+    /**
+     * Calculates the 2nd derivative of the LOG Likelihood with respect to the person ability parameter
+     *
+     * @param array<float> $pp - person ability parameter
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $k - answer category (0 or 1.0)
+     * @return float - 2nd derivative of log likelihood with respect to $pp
+     */
     public static function log_likelihood_p_p(array $pp, array $ip, float $k): float {
+        $pp = $pp['ability'];
         $a = $ip['difficulty'];
-        return - (exp($a + $pp[0]) / ((exp($a) + exp($pp[0])) ** 2));
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_a = exp($a);
+        $exp_p = exp($pp);
+        
+        return - ($exp_a * $exp_p) / (($exp_a + $exp_p) ** 2);
     }
 
-    public static function get_log_jacobian($pp, array $ip, float $k): array {
+    /**
+     * Calculates the 1st derivative of the LOG Likelihood with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $k - answer category (0 or 1.0)
+     * @return array - jacobian vector
+     */
+    public static function get_log_jacobian(array $pp, array $ip, float $k): array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        
+        $jacobian = [];
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_a = exp($a);
+        $exp_p = exp($pp);
+        
         if ($k >= 1.0) {
-            return [
-                (-exp($ip['difficulty'] + $pp) / ((exp($ip['difficulty']) + exp($pp)) * (exp($pp)))) // The d/da .
-            ];
+            $jacobian[0] = -($exp_a * $exp_p) / (($exp_a + $exp_p) * $exp_p) // The d/da .
         } else {
-            return [
-                (exp($pp) / (exp($ip['difficulty']) + exp($pp))) // The d/da .
-            ];
+            $jacobian[0] = $exp_p / ($exp_a + $exp_p) // The d/da .
         }
+        return $jacobian;
     }
 
-    public static function get_log_hessian($pp, $ip, float $k): array {
+    /**
+     * Calculates the 2nd derivative of the LOG Likelihood with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $k - answer category (0 or 1.0)
+     * @return array - hessian matrx
+     */
+    public static function get_log_hessian(array $pp, $ip, float $k): array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        
+        $hessian = [[]];
+
+        // Pre-Calculate high frequently used exp-terms.        
+        $exp_a = exp($a);
+        $exp_p = exp($pp);
+
         // 2nd derivative is equal for both k = 0 and k = 1
-        return [[
-            -exp($ip['difficulty'] + $pp) / (exp($ip['difficulty']) + exp($pp)) ** 2 // The d²/ da² .
-        ]];
+        $hessian[0][0] = -($exp_a * $exp_p) / ($exp_a + $exp_p) ** 2 // The d²/ da² .
+        return $hessian; 
     }
 
     // Calculate the Least-Mean-Squres (LMS) approach.
+    
     /**
      * Calculates the Least Mean Squres (residuals) for a given the person ability parameter and a given expected/observed score
      *
-     * @param array $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty', 'discrimination', 'guessing')
-     * @param array $k - fraction of correct (0 ... 1.0)
-     * @param array $n - number of observations
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $n - number of observations
      * @return float - weighted residuals
      */
-    public static function least_mean_squares(array $pp, array $ip, array $k, array $n): float {
-        $lmsresiduals = 0;
-        $numbertotal = 0;
-
-        foreach ($pp as $key => $ability) {
-            if (!(is_float($n[$key]) && is_float($k[$key]))) {
-                continue;
-            }
-
-            $lmsresiduals += $n[$key] * ($k[$key] - self::likelihood($ability, $ip, 1.0)) ** 2;
-            $numbertotal += $n[$key];
-        }
-        return (($numbertotal > 0) ? ($lmsresiduals / $numbertotal) : (0));
+   function least_mean_squares(array $pp, array $ip, float $k, float $n):float{
+        return $n * ($k - likelihood($pp, $ip, 1.0)) ** 2;
     }
 
     /**
      * Calculates the 1st derivative of Least Mean Squres with respect to the item parameters
      *
-     * @param array $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty', 'discrimination')
-     * @param array $k - fraction of correct (0 ... 1.0)
-     * @param array $n - number of observations
-     * @return array - 1st derivative
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $n - number of observations
+     * @return array - 1st derivative of lms with respect to $ip
      */
-    public static function least_mean_squares_1st_derivative_ip(array $pp, array $ip, array $k, array $n): array {
-        $derivative = 0;
+   function least_mean_squares_1st_derivative_ip(array $pp, array $ip, float $k, float $n):array{
+        $pp = $pp['ability'];
         $a = $ip['difficulty'];
 
-        foreach ($pp as $key => $ability) {
-            if (!(is_numeric($n[$key]) && is_numeric($k[$key]))) {
-                continue;
-            }
+        $derivative = [];
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_ap0 = exp($a - $pp);
+        
+        $derivative[0] = $n * (2 * $exp_ap0 * ($k - 1 + $exp_ap0 * $k)) / (1 + $exp_ap0) ** 3; // Calculate d/da.            
 
-            $derivative += $n[$key] * (2 * exp($a + $ability) * (exp($a)
-                * $k[$key] + exp($ability) * ($k[$key]) - 1)) / (exp($a) + exp($ability)) ** 3; // Calculate d/da.
-        }
-        return [$derivative];
+        return $derivative;
     }
 
     /**
      * Calculates the 2nd derivative of Least Mean Squres with respect to the item parameters
      *
-     * @param array $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty', 'discrimination')
-     * @param array $k - fraction of correct (0 ... 1.0)
-     * @param array $n - number of observations
-     * @return array - 1st derivative
-     */
-    public static function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, array $k, array $n): array {
-        $derivative = [[0]];
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $n - number of observations
+     * @return array - 2nd derivative of lms with respect to $ip
+     */ 
+   function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, float $k, float $n):array{
+        $pp = $pp['ability'];
         $a = $ip['difficulty'];
 
-        foreach ($pp as $key => $ability) {
-            if (!(is_numeric($n[$key]) && is_numeric($k[$key]))) {
-                continue;
-            }
-
-            // Calculate d²/da².
-            $derivative[0][0]  += $n[$key] * (2 * exp($a + $ability) *
-                                (2 * exp($a + $ability) + exp(2 * $ability) * (-1 + $k[$key]) - exp(2 * $a) * $k[$key]))
-                                / (exp($a) + exp($ability)) ** 4;
-        }
+        $derivative = [[]];
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_bap1 = exp($a + $pp);
+        $exp_bap0 = exp($a - $pp);
+        $exp_a = exp($a);
+        $exp_p = exp($pp):
+        
+        $derivative[0][0]  = $n * (2 * $b ** 2 * ($exp_a * $exp_p) * (-$exp_p ** 2 + 2 * ($exp_a * $exp_p) + (-$exp_a ** 2 + $exp_p ** 2) * $k)) / ($exp_a + $exp_p) ** 4; // Calculate d²2/da². 
+              
         return $derivative;
     }
 
+    // Calculate the Log'ed Odds-Ratio Squared (LORS) approach.
+    
+    /**
+     * Calculates the Log'ed Odds-Ratio Squared (residuals) for a given the person ability parameter and a given expected/observed score
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $or - odds ratio
+     * @param float $n - number of observations
+     * @return float - weighted residuals
+     */   
+    function lors_residuals(array $pp, array $ip, float $or, float $n = 1):float {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        
+        return $n * (log($or) + ($a - $pp)) ** 2;
+    }
+
+    /**
+     * Calculates the 1st derivative of Log'ed Odds-Ratio Squared with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $or - odds ratio
+     * @param float $n - number of observations
+     * @return array - 1st derivative
+     */   
+   function lors_1st_derivative_ip(array $pp, array $ip, float $or, float $n = 1): array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+       
+        $derivative = [];
+
+        $derivative[0] = $n * 2 * ($a - $pp + log($or)); // Calculate d/da.            
+        
+        return $derivative;
+    }
+    
+    /**
+     * Calculates the 2nd derivative of Log'ed Odds-Ratio Squared with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @param float $or - odds ratio
+     * @param float $n - number of observations
+     * @return array - 1st derivative
+     */   
+   function lors_2nd_derivative_ip(array $pp, array $ip, float $or, float $n = 1): array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        
+        $derivative = [[]];
+        
+        $derivative[0][0]  = $n * 2; // Calculate d²2/da².            
+      
+        return $derivative;
+    }
+    
     // Calculate Fisher-Information.
 
     /**
-     * Calculates the Fisher Information for a given person ability parameter.
+     * Calculates the Fisher Information for a given person ability parameter
      *
-     * @param float $pp
-     * @param array $ip
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty')
      * @return float
      */
+
     public static function fisher_info(float $pp, array $ip) {
         return (self::likelihood($pp, $ip, 0) * self::likelihood($pp, $ip, 1.0));
     }
@@ -251,8 +357,8 @@ class raschbirnbauma extends model_raschmodel {
     /**
      * Implements a Filter Function for trusted regions in the item parameter estimation
      *
-     * @param array $ip
-     * return array
+     * @param array<float> $ip - item parameters ('difficulty')
+     * return array - chunked item parameter
      */
     public static function restrict_to_trusted_region(array $ip): array {
         // Set values for difficulty parameter.
@@ -282,9 +388,10 @@ class raschbirnbauma extends model_raschmodel {
     /**
      * Calculates the 1st derivative trusted regions for item parameters
      *
-     * @return array
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @return array - 1st derivative of TR function with respect to $ip
      */
-    public static function get_log_tr_jacobian(): array {
+    public static function get_log_tr_jacobian(array $ip): array {
         // Set values for difficulty parameter.
         $am = 0; // Mean of difficulty.
         $as = 2; // Standard derivation of difficulty.
@@ -292,22 +399,23 @@ class raschbirnbauma extends model_raschmodel {
         $atr = floatval(get_config('catmodel_raschbirnbauma', 'trusted_region_factor_sd_a'));
 
         return [
-            fn ($ip) => (($am - $ip['difficulty']) / ($as ** 2)) // The d/da .
+            ($am - $ip['difficulty']) / ($as ** 2) // The d/da .
         ];
     }
 
     /**
      * Calculates the 2nd derivative trusted regions for item parameters
      *
-     * @return array
+     * @param array<float> $ip - item parameters ('difficulty')
+     * @return array<array> - 2nd derivative of TR function with respect to $ip
      */
-    public static function get_log_tr_hessian(): array {
+    public static function get_log_tr_hessian(array $ip): array {
         // Set values for difficulty parameter.
         $am = 0; // Mean of difficulty.
         $as = 2; // Standard derivation of difficulty.
 
         return [[
-            fn ($x) => (-1 / ($as ** 2)) // Calculate d/da d/da.
+            -1 / ($as ** 2) // Calculate d/da d/da.
         ]];
     }
 }

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -290,7 +290,7 @@ class raschbirnbaumb extends model_raschmodel {
         $exp_bp = exp($b * $pp):
         
         $derivative[0][0]  = $n * (2 * $b ** 2 * $exp_bap1 * (-$exp_bp ** 2 + 2 * $exp_bap1 + (-$exp_ab ** 2 + $exp_bp ** 2) * $frac)) / ($exp_ab + $exp_bp) ** 4; // Calculate d²2/da².            
-        $derivative[0][1]  = $n * (2 * $exp_bap0 * ((1 + $a * $b - $b * $pp) * ($k -1) - $exp_bap0 ** 2 * ($b * ($a - $pp) - 1) * $frac + $exp_bap0 * (2 * $a * $b - 2 * $b * $pp + 2 * $frac - 1))) / (1 + $exp_bap0) ** 4; // Calculate d/da d/db.    
+        $derivative[0][1]  = $n * (2 * $exp_bap0 * ((1 + $a * $b - $b * $pp) * ($frac -1) - $exp_bap0 ** 2 * ($b * ($a - $pp) - 1) * $frac + $exp_bap0 * (2 * $a * $b - 2 * $b * $pp + 2 * $frac - 1))) / (1 + $exp_bap0) ** 4; // Calculate d/da d/db.    
         $derivative[1][1]  = $n * (2 * $exp_bap1 * ($a - $pp) ** 2 * (2 * $exp_bap1 + (-$exp_ab ** 2 + $exp_bp ** 2) * $frac - $exp_bp ** 2)) / ($exp_ab + $exp_bp) ** 4; // Calculate d²/db².
 
         // Note: Partial derivations are exchangeable, cf. Theorem of Schwarz.

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -119,7 +119,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the LOG Likelihood for a given the person ability parameter
      *
      * @param array <float> $pp - person ability parameter ('ability')
-     * @param array $ip - item parameters ('difficulty')
+     * @param array $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - answer category (0 or 1.0)
      * @return float - log likelihood
      */
@@ -150,7 +150,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the 2nd derivative of the LOG Likelihood with respect to the person ability parameter
      *
      * @param array<float> $pp - person ability parameter
-     * @param array<float> $ip - item parameters ('difficulty')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - answer category (0 or 1.0)
      * @return float - 2nd derivative of log likelihood with respect to $pp
      */

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -160,7 +160,7 @@ class raschbirnbaumb extends model_raschmodel {
         $a = $ip['difficulty'];
         $b = $ip['discrimination'];
         
-        return [[-(($b ** 2 * exp($b * ($a + $pp))) / ((exp($a * $b) + exp($b * $pp)) ** 2))]];
+        return -(($b ** 2 * exp($b * ($a + $pp))) / ((exp($a * $b) + exp($b * $pp)) ** 2));
     }
 
     /**

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -232,7 +232,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the Least Mean Squres (residuals) for a given the person ability parameter and a given expected/observed score
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return float - weighted residuals
@@ -245,7 +245,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the 1st derivative of Least Mean Squares with respect to the item parameters
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return array - 1st derivative of lms with respect to $ip
@@ -270,7 +270,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the 2nd derivative of Least Mean Squres with respect to the item parameters
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return array - 2nd derivative of lms with respect to $ip
@@ -304,7 +304,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the Log'ed Odds-Ratio Squared (residuals) for a given the person ability parameter and a given expected/observed score
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $or - odds ratio
      * @param float $n - number of observations
      * @return float - weighted residuals
@@ -321,7 +321,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the 1st derivative of Log'ed Odds-Ratio Squared with respect to the item parameters
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $or - odds ratio
      * @param float $n - number of observations
      * @return array - 1st derivative
@@ -343,7 +343,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the 2nd derivative of Log'ed Odds-Ratio Squared with respect to the item parameters
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $or - odds ratio
      * @param float $n - number of observations
      * @return array - 1st derivative
@@ -371,7 +371,7 @@ class raschbirnbaumb extends model_raschmodel {
      * Calculates the Fisher Information for a given person ability parameter
      *
      * @param array<float> $pp - person ability parameter ('ability')
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @return float
      */
     public static function fisher_info(array $pp, array $ip): float {
@@ -383,7 +383,7 @@ class raschbirnbaumb extends model_raschmodel {
     /**
      * Implements a Filter Function for trusted regions in the item parameter estimation
      *
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * return array - chunked item parameter
      */
      function restrict_to_trusted_region(array $ip): array {
@@ -429,7 +429,7 @@ class raschbirnbaumb extends model_raschmodel {
     /**
      * Calculates the 1st derivative trusted regions for item parameters
      *
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @return array - 1st derivative of TR function with respect to $ip
      */
     function get_log_tr_jacobian($ip): array {
@@ -453,7 +453,7 @@ class raschbirnbaumb extends model_raschmodel {
     /**
      * Calculates the 2nd derivative trusted regions for item parameters
      *
-     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @return array<array> - 2nd derivative of TR function with respect to $ip
      */
     function get_log_tr_hessian(array $ip):array{
@@ -476,5 +476,4 @@ class raschbirnbaumb extends model_raschmodel {
         -($b_s ** 2 * exp($b_s * ($b_p + $ip['discrimination']))) / (exp($b_s * $b_p) + exp($b_s * $ip['discrimination'])) ** 2 // Calculates d²/db².
       ]];  
     }
-    
 }

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -96,8 +96,8 @@ class raschbirnbaumb extends model_raschmodel {
     /**
      * Calculates the Likelihood for a given the person ability parameter
      *
-     * @param array <float> $pp - person ability parameter ('ability')
-     * @param array <float> $ip - item parameters ('difficulty', 'discrimination')
+     * @param array<float> $pp - person ability parameter
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - answer category (0 or 1.0)
      * @return float
      */
@@ -118,8 +118,8 @@ class raschbirnbaumb extends model_raschmodel {
     /**
      * Calculates the LOG Likelihood for a given the person ability parameter
      *
-     * @param array <float> $pp - person ability parameter ('ability')
-     * @param array $ip - item parameters ('difficulty', 'discrimination')
+     * @param array<float> $pp - person ability parameter
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - answer category (0 or 1.0)
      * @return float - log likelihood
      */
@@ -130,7 +130,8 @@ class raschbirnbaumb extends model_raschmodel {
     /**
      * Calculates the 1st derivative of the LOG Likelihood with respect to the item parameters
      *
-     * @param float $pp - person ability parameter
+     * @param array<float> $pp - person ability parameter
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
      * @param float $k - answer category (0 or 1.0)
      * @return float - 1st derivative of log likelihood with respect to $pp
      */

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -107,7 +107,7 @@ class raschbirnbaumb extends model_raschmodel {
         $b = $ip['discrimination'];
         
         if ($k < 1.0) {
-            return 1 / (1 + exp($b * ($pp - $a)));
+            return 1 - self::likelihood($pp, $ip, 1.0);
         } else {
             return 1 / (1 + exp($b * ($a - $pp)));
         }

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -386,7 +386,7 @@ class raschbirnbaumb extends model_raschmodel {
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
      * return array - chunked item parameter
      */
-   function restrict_to_trusted_region(array $ip): array {
+     function restrict_to_trusted_region(array $ip): array {
         // Set values for difficulty parameter.
         $a = $ip['difficulty'];
 
@@ -432,23 +432,22 @@ class raschbirnbaumb extends model_raschmodel {
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
      * @return array - 1st derivative of TR function with respect to $ip
      */
-   function get_log_tr_jacobian($ip): array {
-        // Set values for difficulty parameter.
-        
-        // @DAVID: Diese Werte sollten dynamisch berechnet werden können
-        
-        $a_m = 0; // Mean of difficulty.
-        $a_s = 2; // Standard derivation of difficulty.
+    function get_log_tr_jacobian($ip): array {
+      // Set values for difficulty parameter.
 
-        // Placement of the discriminatory parameter.
-        $b_p = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_placement_b'));
-        // Slope of the discriminatory parameter.
-        $b_s = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_slope_b'));
+      // @DAVID: Diese Werte sollten dynamisch berechnet werden können
+      $a_m = 0; // Mean of difficulty.
+      $a_s = 2; // Standard derivation of difficulty.
 
-        return [
-            (($a_m - $ip['difficulty']) / ($a_s ** 2)), // Calculates d/da.
-            (-($b_s * exp($b_s * $ip['discrimination'])) / (exp($b_s * $b_p) + exp($b_s * $ip['discrimination']))) // Calculates d/db.
-        ];
+      // Placement of the discriminatory parameter.
+      $b_p = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_placement_b'));
+      // Slope of the discriminatory parameter.
+      $b_s = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_slope_b'));
+
+      return [
+        ($a_m - $ip['difficulty']) / ($a_s ** 2), // Calculates d/da.
+        -($b_s * exp($b_s * $ip['discrimination'])) / (exp($b_s * $b_p) + exp($b_s * $ip['discrimination'])) // Calculates d/db.
+      ];
     }
 
     /**
@@ -457,25 +456,25 @@ class raschbirnbaumb extends model_raschmodel {
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
      * @return array<array> - 2nd derivative of TR function with respect to $ip
      */
-   function get_log_tr_hessian(array $ip):array{
-        // Set values for difficulty parameter.
-        
-        // @DAVID: Diese Werte sollten dynamisch berechnet werden können
-            
-        $a_m = 0; // Mean of difficulty.
-        $a_s = 2; // Standard derivation of difficulty.
+    function get_log_tr_hessian(array $ip):array{
+      // Set values for difficulty parameter.
 
-        // Placement of the discriminatory parameter.
-        $b_p = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_placement_b'));
-        // Slope of the discriminatory parameter.
-        $b_s = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_slope_b'));
+      // @DAVID: Diese Werte sollten dynamisch berechnet werden können  
+      $a_m = 0; // Mean of difficulty.
+      $a_s = 2; // Standard derivation of difficulty.
 
-        return [[
-          (-1/ ($a_s ** 2)), // Calculates d²/da².
-          (0) // Calculates d/da d/db.
-        ],[
-          (0), // Calculates d/da d/db.
-          (-($b_s ** 2 * exp($b_s * ($b_p + $ip['discrimination']))) / (exp($b_s * $b_p) + exp($b_s * $ip['discrimination'])) ** 2) // Calculates d²/db².
-        ]];
+      // Placement of the discriminatory parameter.
+      $b_p = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_placement_b'));
+      // Slope of the discriminatory parameter.
+      $b_s = floatval(get_config('catmodel_raschbirnbaumb', 'trusted_region_slope_b'));
+
+      return [[
+        -1/ ($a_s ** 2), // Calculates d²/da².
+        0 // Calculates d/da d/db.
+      ],[
+        0, // Calculates d/da d/db.
+        -($b_s ** 2 * exp($b_s * ($b_p + $ip['discrimination']))) / (exp($b_s * $b_p) + exp($b_s * $ip['discrimination'])) ** 2 // Calculates d²/db².
+      ]];  
     }
+    
 }

--- a/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
+++ b/catmodel/raschbirnbaumb/classes/raschbirnbaumb.php
@@ -234,12 +234,12 @@ class raschbirnbaumb extends model_raschmodel {
      *
      * @param array<float> $pp - person ability parameter ('ability')
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
-     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $frac - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return float - weighted residuals
      */
-   function least_mean_squares(array $pp, array $ip, float $k, float $n):float{
-        return $n * ($k - likelihood($pp, $ip, 1.0)) ** 2;
+   function least_mean_squares(array $pp, array $ip, float $frac, float $n):float{
+        return $n * ($frac - likelihood($pp, $ip, 1.0)) ** 2;
     }
 
     /**
@@ -247,11 +247,11 @@ class raschbirnbaumb extends model_raschmodel {
      *
      * @param array<float> $pp - person ability parameter ('ability')
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
-     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $frac - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return array - 1st derivative of lms with respect to $ip
      */ 
-   function least_mean_squares_1st_derivative_ip(array $pp, array $ip, float $k, float $n):array{
+   function least_mean_squares_1st_derivative_ip(array $pp, array $ip, float $frac, float $n):array{
         $pp = $pp['ability'];
         $a = $ip['difficulty'];
         $b = $ip['discrimination'];
@@ -261,8 +261,8 @@ class raschbirnbaumb extends model_raschmodel {
         // Pre-Calculate high frequently used exp-terms.
         $exp_bap = exp($b * ($a - $pp));
         
-        $derivative[0] = $n * (2 * $b * $exp_bap * ($k -1 + $exp_bap * $k)) / (1 + $exp_bap) ** 3; // Calculate d/da.            
-        $derivative[1] = $n * (2 * $exp_bap * ($a - $pp) * ($k -1 + $exp_bap * $k)) / (1 + $exp_bap) ** 3; // Calculate d/db.
+        $derivative[0] = $n * (2 * $b * $exp_bap * ($frac -1 + $exp_bap * $frac)) / (1 + $exp_bap) ** 3; // Calculate d/da.            
+        $derivative[1] = $n * (2 * $exp_bap * ($a - $pp) * ($frac -1 + $exp_bap * $frac)) / (1 + $exp_bap) ** 3; // Calculate d/db.
 
         return $derivative;
     }
@@ -272,11 +272,11 @@ class raschbirnbaumb extends model_raschmodel {
      *
      * @param array<float> $pp - person ability parameter ('ability')
      * @param array<float> $ip - item parameters ('difficulty', 'discrimination')
-     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $frac - fraction of correct (0 ... 1.0)
      * @param float $n - number of observations
      * @return array - 2nd derivative of lms with respect to $ip
      */ 
-   function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, float $k, float $n):array{
+   function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, float $frac, float $n):array{
         $pp = $pp['ability'];
         $a = $ip['difficulty'];
         $b = $ip['discrimination'];
@@ -289,9 +289,9 @@ class raschbirnbaumb extends model_raschmodel {
         $exp_ab = exp($a * $b);
         $exp_bp = exp($b * $pp):
         
-        $derivative[0][0]  = $n * (2 * $b ** 2 * $exp_bap1 * (-$exp_bp ** 2 + 2 * $exp_bap1 + (-$exp_ab ** 2 + $exp_bp ** 2) * $k)) / ($exp_ab + $exp_bp) ** 4; // Calculate d²2/da².            
-        $derivative[0][1]  = $n * (2 * $exp_bap0 * ((1 + $a * $b - $b * $pp) * ($k -1) - $exp_bap0 ** 2 * ($b * ($a - $pp) - 1) * $k + $exp_bap0 * (2 * $a * $b - 2 * $b * $pp + 2 * $k - 1))) / (1 + $exp_bap0) ** 4; // Calculate d/da d/db.    
-        $derivative[1][1]  = $n * (2 * $exp_bap1 * ($a - $pp) ** 2 * (2 * $exp_bap1 + (-$exp_ab ** 2 + $exp_bp ** 2) * $k - $exp_bp ** 2)) / ($exp_ab + $exp_bp) ** 4; // Calculate d²/db².
+        $derivative[0][0]  = $n * (2 * $b ** 2 * $exp_bap1 * (-$exp_bp ** 2 + 2 * $exp_bap1 + (-$exp_ab ** 2 + $exp_bp ** 2) * $frac)) / ($exp_ab + $exp_bp) ** 4; // Calculate d²2/da².            
+        $derivative[0][1]  = $n * (2 * $exp_bap0 * ((1 + $a * $b - $b * $pp) * ($k -1) - $exp_bap0 ** 2 * ($b * ($a - $pp) - 1) * $frac + $exp_bap0 * (2 * $a * $b - 2 * $b * $pp + 2 * $frac - 1))) / (1 + $exp_bap0) ** 4; // Calculate d/da d/db.    
+        $derivative[1][1]  = $n * (2 * $exp_bap1 * ($a - $pp) ** 2 * (2 * $exp_bap1 + (-$exp_ab ** 2 + $exp_bp ** 2) * $frac - $exp_bp ** 2)) / ($exp_ab + $exp_bp) ** 4; // Calculate d²/db².
 
         // Note: Partial derivations are exchangeable, cf. Theorem of Schwarz.
         $derivative[1][0] = $derivative[0][1];

--- a/catmodel/raschbirnbaumc/classes/raschbirnbaumc.php
+++ b/catmodel/raschbirnbaumc/classes/raschbirnbaumc.php
@@ -95,13 +95,16 @@ class raschbirnbaumc extends model_raschmodel {
     /**
      * Calculates the Likelihood for a given the person ability parameter
      *
-     * @param float $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty')
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
      * @param float $k - answer category (0 or 1.0)
      * @return float
      */
-    public static function likelihood($pp, array $ip, float $k):float {
-        $a = $ip['difficulty']; $b = $ip['discrimination']; $c = $ip['guessing'];
+    public static function likelihood(array $pp, array $ip, float $k):float {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
 
         if ($k < 1.0) {
             return 1 - self::likelihood($pp, $ip, 1.0);
@@ -115,18 +118,28 @@ class raschbirnbaumc extends model_raschmodel {
     /**
      * Calculates the LOG Likelihood for a given the person ability parameter
      *
-     * @param float $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty')
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
      * @param float $k - answer category (0 or 1.0)
      * @return float
      */
-    public static function log_likelihood($pp, array $ip, float $k):float {
+    public static function log_likelihood(array $pp, array $ip, float $k):float {
         return log(self::likelihood($pp, $ip, $k));
     }
 
+    /**
+     * Calculates the 1st derivative of the LOG Likelihood with respect to the item parameters
+     *
+     * @param array <float> $pp - person ability parameter ('ability')
+     * @param array $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - answer category (0 or 1.0)
+     * @return float - 1st derivative of log likelihood with respect to $pp
+     */
     public static function log_likelihood_p(array $pp, array $ip, float $k):float {
-        $pp = $pp[0];
-        $a = $ip['difficulty']; $b = $ip['discrimination']; $c = $ip['guessing'];
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
 
         if ($k < 1.0) {
             return -(($b * exp($b * $pp)) / (exp($a * $b) + exp($b * $pp)));
@@ -135,9 +148,19 @@ class raschbirnbaumc extends model_raschmodel {
         }
     }
 
+    /**
+     * Calculates the 2nd derivative of the LOG Likelihood with respect to the person ability parameter
+     *
+     * @param array<float> $pp - person ability parameter
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - answer category (0 or 1.0)
+     * @return float - 2nd derivative of log likelihood with respect to $pp
+     */
     public static function log_likelihood_p_p(array $pp, array $ip, float $k):float {
-        $pp = $pp[0];
-        $a = $ip['difficulty']; $b = $ip['discrimination']; $c = $ip['guessing'];
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
 
         if ($k < 1.0) {
             return -(($b ** 2 * exp($b * ($a + $pp))) / (exp($a * $b) + exp($b * $pp)) ** 2);
@@ -146,53 +169,82 @@ class raschbirnbaumc extends model_raschmodel {
         }
     }
 
+    /**
+     * Calculates the 1st derivative of the LOG Likelihood with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - answer category (0 or 1.0)
+     * @return array - jacobian vector
+     */
     public static function get_log_jacobian($pp, $ip, float $k):array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
+                
+        $jacobian = [];
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_ab = exp($a * $b);
+        $exp_bp = exp($b * $pp);
+        $exp_bap1 = exp($b * ($a + $pp));
+        $exp_bap0 = exp($b * ($a - $ $pp));
+        
         if ($k >= 1.0) {
-            return [
-                ($ip['discrimination'] * ($ip['guessing'] - 1) * exp($ip['discrimination'] * ($ip['difficulty'] + $pp))) / ((exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) * ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp))), // Calculate d/da.
-                (($ip['guessing'] - 1) * exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) * ($ip['difficulty'] - $pp)) / ((exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) * ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp))), // Calculate d/db.
-                exp($ip['difficulty'] * $ip['discrimination']) / ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) // Calculate d/dc.
-            ];
+            $jacobian[0] = ($b * ($c - 1) * $exp_bap1) / (($exp_ab + $exp_bp) * ($c * $exp_ab + $exp_bp)), // Calculate d/da.
+            $jacobian[1] = (($c - 1) * $exp_bap1 * ($a - $pp)) / (($exp_ab + $exp_bp) * ($c * $exp_ab + $exp_bp)), // Calculate d/db.
+            $jacobian[2] = $exp_ab / ($c * $exp_ab + $exp_bp) // Calculate d/dc.
         } else {
-            return [
-                $ip['discrimination'] / (1 + exp($ip['discrimination'] * ($ip['difficulty'] - $pp))), // Calculate d/da.
-                ($ip['difficulty'] - $pp) / (1 + exp($ip['discrimination'] * ($ip['difficulty'] - $pp))), // Calculate d/db.
-                1 / ($ip['guessing'] - 1) // Calculate d/dc.
-            ];
+            $jacobian[0] = $b / (1 + $exp_bap0), // Calculate d/da.
+            $jacobian[1] = ($a - $pp) / (1 + $exp_bap0), // Calculate d/db.
+            $jacobian[2] = 1 / ($c - 1) // Calculate d/dc.
         }
+        return $jacobian;
     }
 
+    /**
+     * Calculates the 2nd derivative of the LOG Likelihood with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - answer category (0 or 1.0)
+     * @return array - hessian matrx
+     */
     public static function get_log_hessian($pp, $ip, float $k):array {
-
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
+        
+        $hessian = [[]];
+        
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_ab = exp($a * $b);
+        $exp_bp = exp($b * $pp);
+        
         if ($k >= 1.0) {
-            return [[
-                -($ip['discrimination'] ** 2 * ($ip['guessing'] - 1) * exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) * ($ip['guessing'] * exp(2 * $ip['difficulty'] * $ip['discrimination']) - exp(2 * $ip['discrimination'] * $pp))) / ((exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2 * ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2), // Calculate d²/ da².
-                (($ip['guessing'] - 1) * exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) * (exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) + exp(2 * $ip['discrimination'] * $pp) * (1 + $ip['difficulty'] * $ip['discrimination'] - $ip['discrimination'] * $pp) + $ip['guessing'] * (exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) + exp(2 * $ip['difficulty'] * $ip['discrimination']) * (1 - $ip['difficulty'] * $ip['discrimination'] + $ip['discrimination'] * $pp)))) / ((exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2 * ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2), // Calculate d/da d/db.
-                ($ip['discrimination'] * exp($ip['discrimination'] * ($ip['difficulty'] + $pp))) / ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2 // d/da d/dc
-            ], [
-                (($ip['guessing'] - 1) * exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) * (exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) + exp(2 * $ip['discrimination'] * $pp) * (1 + $ip['difficulty'] * $ip['discrimination'] - $ip['discrimination'] * $pp) + $ip['guessing'] * (exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) + exp(2 * $ip['difficulty'] * $ip['discrimination']) * (1 - $ip['difficulty'] * $ip['discrimination'] + $ip['discrimination'] * $pp)))) / ((exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2 * ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2), // Calculate d/da d/db.
-                -(($ip['guessing'] - 1) * exp($ip['discrimination'] * ($ip['difficulty'] - $pp)) * ($ip['guessing'] * exp(2 * $ip['discrimination'] * ($ip['difficulty'] - $pp)) - 1) * ($ip['difficulty'] - $pp) ** 2) / (((1 + exp($ip['discrimination'] * ($ip['difficulty'] - $pp))) * (1 + $ip['guessing'] * exp($ip['discrimination'] * ($ip['difficulty'] - $pp)))) ** 2), // Calculate d²/db².
-                (exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) * ($ip['difficulty'] - $pp)) / ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2 // Calculate d/db d/dc.
-            ], [
-                ($ip['discrimination'] * exp($ip['discrimination'] * ($ip['difficulty'] + $pp))) / ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2, // Calculate d/da d/dc.
-                (exp($ip['discrimination'] * ($ip['difficulty'] + $pp)) * ($ip['difficulty'] - $pp)) / ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2, // Calculate d/db d/dc.
-                -exp(2 * $ip['difficulty'] * $ip['discrimination']) / ($ip['guessing'] * exp($ip['difficulty'] * $ip['discrimination']) + exp($ip['discrimination'] * $pp)) ** 2 // Calculate d²/dc².
-            ]];
+            $hessian[0][0] = -($b ** 2 * ($c - 1) * exp($b * ($a + $pp)) * ($c * exp(2 * $a * $b) - exp(2 * $b * $pp))) / ((exp($a * $b) + exp($b * $pp)) ** 2 * ($c * exp($a * $b) + exp($b * $pp)) ** 2), // Calculate d²/ da².
+            $hessian[0][1] = (($c - 1) * exp($b * ($a + $pp)) * (exp($b * ($a + $pp)) + exp(2 * $b * $pp) * (1 + $a * $b - $b * $pp) + $c * (exp($b * ($a + $pp)) + exp(2 * $a * $b) * (1 - $a * $b + $b * $pp)))) / ((exp($a * $b) + exp($b * $pp)) ** 2 * ($c * exp($a * $b) + exp($b * $pp)) ** 2), // Calculate d/da d/db.
+            $hessian[0][2] = ($b * exp($b * ($a + $pp))) / ($c * exp($a * $b) + exp($b * $pp)) ** 2 // d/da d/dc
+            $hessian[1][0] = $hessian[0][1];
+            $hessian[1][1] =  -(($c - 1) * exp($b * ($a - $pp)) * ($c * exp(2 * $b * ($a - $pp)) - 1) * ($a - $pp) ** 2) / (((1 + exp($b * ($a - $pp))) * (1 + $c * exp($b * ($a - $pp)))) ** 2), // Calculate d²/db².
+            $hessian[1][2] =  (exp($b * ($a + $pp)) * ($a - $pp)) / ($c * exp($a * $b) + exp($b * $pp)) ** 2 // Calculate d/db d/dc.
+            $hessian[2][0] = $hessian[0][2];
+            $hessian[2][1] = $hessian[1][2];
+            $hessian[2][2] = -exp(2 * $a * $b) / ($c * exp($a * $b) + exp($b * $pp)) ** 2 // Calculate d²/dc².
         } else {
-            return [[
-                -($ip['discrimination'] ** 2 * exp($ip['discrimination'] * ($ip['difficulty'] - $pp))) / (1 + exp($ip['discrimination'] * ($ip['difficulty'] - $pp))) ** 2, // Calculate d²/da².
-                (exp($ip['discrimination'] * ($ip['difficulty'] - $pp)) * ($ip['discrimination'] * ($pp - $ip['difficulty']) + 1) + 1) / (exp($ip['discrimination'] * ($ip['difficulty'] - $pp)) + 1) ** 2, // Calculate d/da d/db.
-                0 // Calculate d/da d/dc.
-            ], [
-                (exp($ip['discrimination'] * ($ip['difficulty'] - $pp)) * ($ip['discrimination'] * ($pp - $ip['difficulty']) + 1) + 1) / (exp($ip['discrimination'] * ($ip['difficulty'] - $pp)) + 1) ** 2, // Calculate d/da d/db.
-                -(exp($ip['discrimination'] * ($ip['difficulty'] - $pp)) * ($ip['difficulty'] - $pp) ** 2) / (1 + exp($ip['discrimination'] * ($ip['difficulty'] - $pp))) ** 2, // Calculate .d²/db²
-                0 // Calculate d/db d/dc.
-            ], [
-                0, // Calculate d/da d/dc.
-                0, // Calculate d/db d/dc.
-                -1 / ($ip['guessing'] - 1) ** 2 // Calculate d²/dc².
-                ]];
+            $hessian[0][0] = -($b ** 2 * exp($b * ($a - $pp))) / (1 + exp($b * ($a - $pp))) ** 2, // Calculate d²/da².
+            $hessian[0][1] = (exp($b * ($a - $pp)) * ($b * ($pp - $a) + 1) + 1) / (exp($b * ($a - $pp)) + 1) ** 2, // Calculate d/da d/db.
+            $hessian[0][2] =  0 // Calculate d/da d/dc.
+            $hessian[1][0] = $hessian[0][1];          
+            $hessian[1][1] = -(exp($b * ($a - $pp)) * ($a - $pp) ** 2) / (1 + exp($b * ($a - $pp))) ** 2, // Calculate .d²/db²
+            $hessian[1][2] =  0 // Calculate d/db d/dc.
+            $hessian[2][0] = $hessian[0][2];
+            $hessian[2][1] = $hessian[1][2];           
+            $hessian[2][2] = -1 / ($c - 1) ** 2 // Calculate d²/dc².
         }
+        return $hessian;
     }
 
     // Calculate the Least-Mean-Squres (LMS) approach.
@@ -200,97 +252,71 @@ class raschbirnbaumc extends model_raschmodel {
     /**
      * Calculates the Least Mean Squres (residuals) for a given the person ability parameter and a given expected/observed score
      *
-     * @param array $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty', 'discrimination', 'guessing')
-     * @param array $k - fraction of correct (0 ... 1.0)
-     * @param array $n - number of observations
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $n - number of observations
      * @return float - weighted residuals
      */
-    public static function least_mean_squares(array $pp, array $ip, array $k, array $n):float {
-        $lmsresiduals = 0;
-        $numbertotal = 0;
-
-        foreach ($pp as $key => $ability) {
-            if (!(is_float($n[$key]) && is_float($k[$key]))) {
-                continue;
-            }
-
-            $lmsresiduals += $n[$key] * ($k[$key] - self::likelihood($ability, $ip, 1.0)) ** 2;
-             $numbertotal += $n[$key];
-        }
-        return (($numbertotal > 0) ? ($lmsresiduals / $numbertotal) : (0));
+   function least_mean_squares(array $pp, array $ip, float $k, float $n):float{
+        return $n * ($k - likelihood($pp, $ip, 1.0)) ** 2;
     }
 
     /**
-     * Calculates the 1st derivative of Least Mean Squres with respect to the item parameters
+     * Calculates the 1st derivative of Least Mean Squares with respect to the item parameters
      *
-     * @param array $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty', 'discrimination')
-     * @param array $k - fraction of correct (0 ... 1.0)
-     * @param array $n - number of observations
-     * @return array - 1st derivative
-     */
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $n - number of observations
+     * @return array - 1st derivative of lms with respect to $ip
+     */ 
     public static function least_mean_squares_1st_derivative_ip(array $pp, array $ip, array $k, array $n) {
-        $derivative = [0, 0, 0];
-        $a = $ip['difficulty']; $b = $ip['discrimination']; $c = $ip['guessing'];
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
+        
+        $derivative = [];
 
-        foreach ($pp as $key => $ability) {
-            if (!(is_numeric($n[$key]) && is_numeric($k[$key]))) {
-                continue;
-            }
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_bap = exp($b * ($a - $pp));
+        
+        $derivative[0] = $n * (-(2 * $b * (1 - $c) * exp($b * ($a - $pp))) / (1 + exp($b * ($a - $pp)) - $k) ** 3); // Calculate d/da.
+        $derivative[1] = $n* (-(2 * (1 - $c) * exp($b * ($a - $pp)) * ($c + (1 - $c) / (1 + exp($b * ($a - $pp))) - $k) * ($a - $pp)) / (1 + exp($b * ($a - $pp))) ** 2); // Calculate d/db.
+        $derivative[2] = $n * 2 * (1 - 1 / (1 + exp($b * ($a - $pp)))) * ($c + (1 - $c) / (1 + exp($b * ($a - $pp))) - $k); // Calculate d/dc.
 
-            $derivative[0] += $n[$key] * (-(2 * $b * (1 - $c) * exp($b * ($a - $ability)))
-                / (1 + exp($b * ($a - $ability)) - $k[$key]) ** 3); // Calculate d/da.
-            $derivative[1] += $n[$key] * (-(2 * (1 - $c) * exp($b * ($a - $ability))
-                * ($c + (1 - $c) / (1 + exp($b * ($a - $ability))) - $k[$key]) * ($a - $ability))
-                / (1 + exp($b * ($a - $ability))) ** 2); // Calculate d/db.
-            $derivative[2] += $n[$key] * 2 * (1 - 1 / (1 + exp($b * ($a - $ability)))) * ($c + (1 - $c)
-                / (1 + exp($b * ($a - $ability))) - $k[$key]); // Calculate d/dc.
-        }
         return $derivative;
     }
 
     /**
      * Calculates the 2nd derivative of Least Mean Squres with respect to the item parameters
      *
-     * @param array $pp - person ability parameter
-     * @param array $ip - item parameters ('difficulty', 'discrimination')
-     * @param array $k - fraction of correct (0 ... 1.0)
-     * @param array $n - number of observations
-     * @return array - 1st derivative
-     */
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $k - fraction of correct (0 ... 1.0)
+     * @param float $n - number of observations
+     * @return array - 2nd derivative of lms with respect to $ip
+     */ 
     public static function least_mean_squares_2nd_derivative_ip(array $pp, array $ip, array $k, array $n) {
-        $derivative = [[0, 0, 0], [0, 0, 0], [0, 0, 0]];
+        $pp = $pp['ability'];
         $a = $ip['difficulty'];
         $b = $ip['discrimination'];
         $c = $ip['guessing'];
+        
+        $derivative = [[]];
 
-        foreach ($pp as $key => $ability) {
-            if (!(is_numeric($n[$key]) && is_numeric($k[$key]))) {
-                continue;
-            }
-
-            $derivative[0][0]  += $n[$key] * (-(2 * $b ** 2 * (1 - $c) * exp($b * ($a - $ability)) * ((1 - $c)
-                / (exp($b * ($a - $ability)) + 1) + $c - $k[$key])) / (exp($b * ($a - $ability)) + 1) ** 2
-                + (4 * $b ** 2 * (1 - $c) * exp(2 * $b * ($a - $ability)) * ((1 - $c) / (exp($b * ($a - $ability)) + 1) + $c - $k[$key]))
-                / (exp($b * ($a - $ability)) + 1) ** 3 + (2 * $b ** 2 * (1 - $c) ** 2 * exp(2 * $b * ($a - $ability)))
-                / (exp($b * ($a - $ability)) + 1) ** 4); // Calculate d²/da².
-            $derivative[0][1]  += $n[$key] * (-(2 * (1 - $c) * exp($b * ($a - $ability)) * ((1 - $c) / (exp($b * ($a - $ability)) + 1)
-                + $c - $k[$key])) / (exp($b * ($a - $ability)) + 1) ** 2 - (2 * $b * (1 - $c) * ($a - $ability)
-                * exp($b * ($a - $ability)) * ((1 - $c) / (exp($b * ($a - $ability)) + 1) + $c - $k[$key])) / (exp($b * ($a - $ability)) + 1)
-                ** 2 + (4 * $b * (1 - $c) * ($a - $ability) * exp(2 * $b * ($a - $ability)) * ((1 - $c) / (exp($b * ($a - $ability)) + 1)
-                + $c - $k[$key])) / (exp($b * ($a - $ability)) + 1) ** 3 + (2 * $b * (1 - $c) ** 2 * ($a - $ability)
-                * exp(2 * $b * ($a - $ability))) / (exp($b * ($a - $ability)) + 1) ** 4); // Calculate d/da d/db.
-            $derivative[0][2]  += $n[$key] * (2 * $b * exp($b * ($a - $ability)) * ((2 * $c - $k[$key] - 1)
-                * exp($b * ($a - $ability)) - $k[$key] + 1)) / (exp($b * ($a - $ability)) + 1) ** 3; // Calculate d/da d/dc.
-            $derivative[1][1]  += $n[$key] * (2 * ($a - $ability) * exp($b * ($a - $ability)) * ((1 - $c)
-                / (exp($b * ($a - $ability)) + 1) + $c - $k[$key])) / (exp($b * ($a - $ability)) + 1) ** 2
-                - (2 * (1 - $c) * ($a - $ability) * exp($b * ($a - $ability)) * (1 - 1 / (exp($b * ($a - $ability)) + 1)))
-                / (exp($b * ($a - $ability)) + 1) ** 2; // Calculate d²/db².
-            $derivative[1][2]  += $n[$key] * (2 * ($a - $ability) * exp($b * ($a - $ability)) * ((2 * $c - $k[$key] - 1)
-                * exp($b * ($a - $ability)) - $k[$key] + 1)) / (exp($b * ($a - $ability)) + 1) ** 3; // Calculate d/db d/dc.
-            $derivative[2][2]  += $n[$key] * (2 * exp(2 * $a * $b)) / (exp($a * $b) + exp($b * $ability)) ** 2; // Calculate d²/dc².
-        }
+        // Pre-Calculate high frequently used exp-terms.
+        $exp_bap = exp($b * ($a - $pp));
+        $exp_ab = exp($a * $b);
+        $exp_bp = exp($b * $pp);
+        
+        $derivative[0][0]  = $n * (-(2 * $b ** 2 * (1 - $c) * $exp_bap * ((1 - $c) / ($exp_bap + 1) + $c - $k)) / ($exp_bap + 1) ** 2 + (4 * $b ** 2 * (1 - $c) * $exp_bap ** 2 * ((1 - $c) / ($exp_bap + 1) + $c - $k)) / ($exp_bap + 1) ** 3 + (2 * $b ** 2 * (1 - $c) ** 2 * $exp_bap ** 2) / ($exp_bap + 1) ** 4); // Calculate d²/da².
+        $derivative[0][1]  = $n * (-(2 * (1 - $c) * $exp_bap * ((1 - $c) / ($exp_bap + 1) + $c - $k)) / ($exp_bap + 1) ** 2 - (2 * $b * (1 - $c) * ($a - $pp) * $exp_bap * ((1 - $c) / ($exp_bap + 1) + $c - $k)) / ($exp_bap + 1) ** 2 + (4 * $b * (1 - $c) * ($a - $pp) * $exp_bap ** 2 * ((1 - $c) / ($exp_bap + 1) + $c - $k)) / ($exp_bap + 1) ** 3 + (2 * $b * (1 - $c) ** 2 * ($a - $pp) * $exp_bap ** 2) / ($exp_bap + 1) ** 4); // Calculate d/da d/db.
+        $derivative[0][2]  0 $n * (2 * $b * $exp_bap * ((2 * $c - $k - 1) * $exp_bap - $k + 1)) / ($exp_bap + 1) ** 3; // Calculate d/da d/dc.
+        $derivative[1][1]  0 $n * (2 * ($a - $pp) * $exp_bap * ((1 - $c) / ($exp_bap + 1) + $c - $k)) / ($exp_bap + 1) ** 2 - (2 * (1 - $c) * ($a - $pp) * $exp_bap * (1 - 1 / ($exp_bap + 1))) / ($exp_bap + 1) ** 2; // Calculate d²/db².
+        $derivative[1][2]  0 $n * (2 * ($a - $pp) * $exp_bap * ((2 * $c - $k - 1) * $exp_bap - $k + 1)) / ($exp_bap + 1) ** 3; // Calculate d/db d/dc.
+        $derivative[2][2]  = $n * (2 * $exp_ab ** 2) / ($exp_ab + $exp_bp) ** 2; // Calculate d²/dc².
 
         // Note: Partial derivations are exchangeible, cf. Theorem of Schwarz.
         $derivative[1][0] = $derivative[0][1];
@@ -300,26 +326,96 @@ class raschbirnbaumc extends model_raschmodel {
         return $derivative;
     }
 
+
+    // Calculate the Log'ed Odds-Ratio Squared (LORS) approach.
+    
+    /**
+     * Calculates the Log'ed Odds-Ratio Squared (residuals) for a given the person ability parameter and a given expected/observed score
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $or - odds ratio
+     * @param float $n - number of observations
+     * @return float - weighted residuals
+     */   
+    function lors_residuals(array $pp, array $ip, float $or, float $n = 1):float {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
+        
+        return $n * (log($or) + $b * ($a - $pp)) ** 2;
+    }
+
+    /**
+     * Calculates the 1st derivative of Log'ed Odds-Ratio Squared with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $or - odds ratio
+     * @param float $n - number of observations
+     * @return array - 1st derivative
+     */   
+   function lors_1st_derivative_ip(array $pp, array $ip, float $or, float $n = 1): array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
+       
+        $derivative = [];
+
+        $derivative[0] = $n * 2 * $b * ($b * ($a - $pp) + log($or)); // Calculate d/da.            
+        $derivative[1] = $n * 2 * ($a - $pp) * ($b * ($a - $pp) + log($or)); // Calculate d/db.
+        
+        return $derivative;
+    }
+    
+    /**
+     * Calculates the 2nd derivative of Log'ed Odds-Ratio Squared with respect to the item parameters
+     *
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @param float $or - odds ratio
+     * @param float $n - number of observations
+     * @return array - 1st derivative
+     */   
+   function lors_2nd_derivative_ip(array $pp, array $ip, float $or, float $n = 1): array {
+        $pp = $pp['ability'];
+        $a = $ip['difficulty'];
+        $b = $ip['discrimination'];
+        $c = $ip['guessing'];
+        
+        $derivative = [[]];
+        
+        $derivative[0][0]  = $n * 2 * $b ** 2; // Calculate d²2/da².            
+        $derivative[0][1]  = 0; // $n * 2 * (2 * $b * ($a - $pp) + log($or)); // Calculate d/da d/db.    
+        $derivative[1][1]  = $n * 2 * ($a - $pp) ** 2; // Calculate d²/db².
+
+        // Note: Partial derivations are exchangeable, cf. Theorem of Schwarz.
+        $derivative[1][0] = $derivative[0][1];
+      
+        return $derivative;
+    }
+    
     // Calculate Fisher-Information.
 
     /**
      * Calculates the Fisher Information for a given person ability parameter
      *
-     * @param float $pp
-     * @param array $ip
+     * @param array<float> $pp - person ability parameter ('ability')
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
      * @return float
      */
-    public static function fisher_info($pp, $ip) {
+
+    public static function fisher_info(array $pp, array $ip) {
         return $ip['difficulty'] ** 2 * (1 - $ip['guessing']) * self::likelihood($pp, $ip, 1.0) * (self::likelihood($pp, $ip, 0.0));
     }
-
-    // Implements handling of the Trusted Regions (TR) approach.
 
     /**
      * Implements a Filter Function for trusted regions in the item parameter estimation
      *
-     * @param array $ip
-     * return array
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * return array - chunked item parameter
      */
     public static function restrict_to_trusted_region(array $ip): array {
         // Set values for difficulty parameter.
@@ -387,9 +483,10 @@ class raschbirnbaumc extends model_raschmodel {
     /**
      * Calculates the 1st derivative trusted regions for item parameters
      *
-     * @return array
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @return array - 1st derivative of TR function with respect to $ip
      */
-    public static function get_log_tr_jacobian(): array {
+    public static function get_log_tr_jacobian(array $ip): array {
         // Set values for difficulty parameter.
         $am = 0; // Mean of difficulty.
         $as = 2; // Standard derivation of difficulty.
@@ -400,19 +497,20 @@ class raschbirnbaumc extends model_raschmodel {
         $bs = floatval(get_config('catmodel_raschbirnbaumc', 'trusted_region_slope_b'));
 
         return [
-            fn ($ip) => (($am - $ip['difficulty']) / ($as ** 2)), // Calculate d/da.
+            ($am - $ip['difficulty']) / ($as ** 2), // Calculate d/da.
             // Calculate d/db.
-            fn ($ip) => (-($bs * exp($bs * $ip['discrimination'])) / (exp($bs * $bp) + exp($bs * $ip['discrimination']))),
-            fn ($ip) => (0) // Calculate d/dc.
+            -($bs * exp($bs * $ip['discrimination'])) / (exp($bs * $bp) + exp($bs * $ip['discrimination'])),
+            0 // Calculate d/dc.
         ];
     }
 
     /**
      * Calculates the 2nd derivative trusted regions for item parameters
      *
-     * @return array
+     * @param array<float> $ip - item parameters ('difficulty', 'discrimination', 'guessing')
+     * @return array<array> - 2nd derivative of TR function with respect to $ip
      */
-    public static function get_log_tr_hessian(): array {
+    public static function get_log_tr_hessian(array $ip): array {
         // Set values for difficulty parameter.
         $am = 0; // Mean of difficulty.
         $as = 2; // Standard derivation of difficulty.
@@ -423,17 +521,17 @@ class raschbirnbaumc extends model_raschmodel {
         $bs = floatval(get_config('catmodel_raschbirnbaumc', 'trusted_region_slope_b'));
 
         return [[
-            fn ($ip) => (-1 / ($as ** 2)), // Calculate d²/da².
-            fn ($ip) => (0), // Calculate d/da d/db.
-            fn ($ip) => (0) // Calculate d/da d/dc.
+            -1 / ($as ** 2), // Calculate d²/da².
+            0, // Calculate d/da d/db.
+            0 // Calculate d/da d/dc.
         ], [
-            fn ($ip) => (0), // The d/da d/db.
-            fn ($ip) => (-($bs ** 2 * exp($bs * ($bp + $ip['discrimination']))) / (exp($bs * $bp) + exp($bs * $ip['discrimination'])) ** 2), // d²/db²
-            fn ($ip) => (0) // Calculate d/db d/dc.
+            0, // The d/da d/db.
+            -($bs ** 2 * exp($bs * ($bp + $ip['discrimination']))) / (exp($bs * $bp) + exp($bs * $ip['discrimination'])) ** 2, // d²/db²
+            0 // Calculate d/db d/dc.
         ], [
-            fn ($ip) => (0), // Calculate d/da d/dc.
-            fn ($ip) => (0), // Calculate d/db d/dc.
-            fn ($ip) => (0)// Calculate d²/dc².
+            0, // Calculate d/da d/dc.
+            0, // Calculate d/db d/dc.
+            0 // Calculate d²/dc².
         ]];
     }
 }

--- a/catmodel/raschbirnbaumc/classes/raschbirnbaumc.php
+++ b/catmodel/raschbirnbaumc/classes/raschbirnbaumc.php
@@ -281,10 +281,10 @@ class raschbirnbaumc extends model_raschmodel {
 
         // Pre-Calculate high frequently used exp-terms.
         $exp_bap = exp($b * ($a - $pp));
-        
-        $derivative[0] = $n * (-(2 * $b * (1 - $c) * exp($b * ($a - $pp))) / (1 + exp($b * ($a - $pp)) - $k) ** 3); // Calculate d/da.
-        $derivative[1] = $n* (-(2 * (1 - $c) * exp($b * ($a - $pp)) * ($c + (1 - $c) / (1 + exp($b * ($a - $pp))) - $k) * ($a - $pp)) / (1 + exp($b * ($a - $pp))) ** 2); // Calculate d/db.
-        $derivative[2] = $n * 2 * (1 - 1 / (1 + exp($b * ($a - $pp)))) * ($c + (1 - $c) / (1 + exp($b * ($a - $pp))) - $k); // Calculate d/dc.
+
+        $derivative[0] = $n * (-(2 * $b * (1 - $c) * $exp_bap) / (1 + $exp_bap - $k) ** 3); // Calculate d/da.
+        $derivative[1] = $n* (-(2 * (1 - $c) * $exp_bap * ($c + (1 - $c) / (1 + $exp_bap) - $k) * ($a - $pp)) / (1 + $exp_bap) ** 2); // Calculate d/db.
+        $derivative[2] = $n * 2 * (1 - 1 / (1 + $exp_bap)) * ($c + (1 - $c) / (1 + $exp_bap) - $k); // Calculate d/dc.
 
         return $derivative;
     }
@@ -364,9 +364,11 @@ class raschbirnbaumc extends model_raschmodel {
        
         $derivative = [];
 
+        // @RALF: Korrekte Formeln für 3PL implementieren!
+
         $derivative[0] = $n * 2 * $b * ($b * ($a - $pp) + log($or)); // Calculate d/da.            
         $derivative[1] = $n * 2 * ($a - $pp) * ($b * ($a - $pp) + log($or)); // Calculate d/db.
-        
+
         return $derivative;
     }
     
@@ -386,6 +388,8 @@ class raschbirnbaumc extends model_raschmodel {
         $c = $ip['guessing'];
         
         $derivative = [[]];
+
+        // @RALF: Korrekte Formeln für 3PL implementieren!
         
         $derivative[0][0]  = $n * 2 * $b ** 2; // Calculate d²2/da².            
         $derivative[0][1]  = 0; // $n * 2 * (2 * $b * ($a - $pp) + log($or)); // Calculate d/da d/db.    


### PR DESCRIPTION
Implemented:
* LORS approach

Updated:
* $pp as array['ability'] at all methods
* pre-calculate expensive EXP-functions (5 to 6 times faster now)
* stripped all remaining nested callables

ToDo:
* interface definition has to be updated
* UNIT-tests have to been updated
* calls for all mehods shold be now something like xxx(['ability' => $pp], ... (if $pp is handled as a float)
* some pre-calculations in the Trusted Regions methods (mean, standard deviation of $ip values)
* lines 62-93 seems to be deprecated/unsued and should be checked and removed

