### PR TITLE
GH-155 Only recalculate params when needed

### DIFF
--- a/classes/catcontext.php
+++ b/classes/catcontext.php
@@ -502,4 +502,12 @@ class catcontext {
         // If no record was found, return false.
         return false;
     }
+
+    /**
+     * Returns the time when the items of this context have last been updated.
+     * @return int
+     */
+    public function gettimecalculated(): int {
+        return $this->timecalculated;
+    }
 }

--- a/classes/catmodel_info.php
+++ b/classes/catmodel_info.php
@@ -137,11 +137,11 @@ class catmodel_info {
      * Checks if there are new responses to the questions associated with a CAT
      * context and a CAT scale.
      *
-     * @param mixed $context
-     * @param mixed $catscaleid
+     * @param catcontext $context
+     * @param int $catscaleid
      * @return bool
      */
-    public function needs_update(catcontext $context, int $catscaleid) {
+    public function needs_update(catcontext $context, int $catscaleid): bool {
         global $DB;
         $subscales = catscale::get_subscale_ids($catscaleid);
         [$sql, $params] = catquiz::get_sql_for_new_responses(

--- a/classes/catmodel_info.php
+++ b/classes/catmodel_info.php
@@ -114,9 +114,6 @@ class catmodel_info {
             $model = get_string('pluginname', 'catmodel_'.$modelname);
             $updatedmodels[$model] = $itemcounter;
         }
-        // One item might have been recalculated by different models. We just
-        // want to know the total number of items.
-        $itemcounter = count(array_unique($updateditems));
 
         $updatedmodelsjson = json_encode($updatedmodels);
         // Trigger event.
@@ -139,10 +136,10 @@ class catmodel_info {
     /**
      * Checks if there are new responses to the questions associated with a CAT
      * context and a CAT scale.
-     * 
-     * @param mixed $context 
-     * @param mixed $catscaleid 
-     * @return bool 
+     *
+     * @param mixed $context
+     * @param mixed $catscaleid
+     * @return bool
      */
     public function needs_update(catcontext $context, int $catscaleid) {
         global $DB;

--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -542,9 +542,10 @@ class catquiz {
      * Returns the number of new responses since $lastcalclation for a CAT
      * context and a list of CAT scales.
      *
-     * @param int $contextid
-     * @param array<int> $catscaleids
-     * @param int $lastcalculation
+     * @param int   $contextid
+     * @param array $catscaleids
+     * @param int   $lastcalculation
+     *
      * @return array
      */
     public static function get_sql_for_new_responses(int $contextid, array $catscaleids, int $lastcalculation) {

--- a/classes/task/recalculate_cat_model_params.php
+++ b/classes/task/recalculate_cat_model_params.php
@@ -70,6 +70,9 @@ class recalculate_cat_model_params extends \core\task\scheduled_task {
         $cmi = new catmodel_info();
         foreach ($contexts as $context) {
             foreach ($catscales as $catscale) {
+                if (! $cmi->needs_update($context, $catscale->id)) {
+                    continue;
+                }
                 $cmi->update_params($context->id, $catscale->id);
             }
         }


### PR DESCRIPTION
Adds a new function that gets the number of new responses since a given timepoint. Recalculation is now only performed if there is a new response associated to a CAT context and CAT scales.
The event that informs about recalculations now gets a correct number of updated items: a recalculation for an item is counted only once, even if its recalculated by more than one model.

Closes #155 
Closes #168 