### PR TITLE
GH-184 Configure feedback generators per strategy

### DIFF
--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -160,11 +160,7 @@ class attemptfeedback implements renderable, templatable {
             return [];
         }
 
-        $generators = array_map(
-            fn ($classname) => new $classname(),
-            $attemptstrategy->get_feedbackgenerators());
-
-        return $generators;
+        return $attemptstrategy->get_feedbackgenerators();
     }
 
     /**

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -48,11 +48,11 @@ class customscalefeedback extends feedbackgenerator {
     /**
      * Creates a new customscale feedback generator.
      *
-     * @param callable $sortfun Optional. A function to order the feedbacks by
+     * @param ?callable $sortfun Optional. A function to order the feedbacks by
      * their scale ability. If none is given, the feedbacks are displayed in
      * ascending order of their ability.
      */
-    public function __construct(?callable $sortfun = null) {
+    public function __construct($sortfun = null) {
         $this->sortfun = $sortfun ?? fn(&$x) => asort($x);
     }
 

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -41,6 +41,22 @@ use local_catquiz\teststrategy\feedbackgenerator;
 class customscalefeedback extends feedbackgenerator {
 
     /**
+     * @var callable $sortfun
+     */
+    private $sortfun;
+
+    /**
+     * Creates a new customscale feedback generator.
+     *
+     * @param callable $sortfun Optional. A function to order the feedbacks by
+     * their scale ability. If none is given, the feedbacks are displayed in
+     * ascending order of their ability.
+     */
+    public function __construct(?callable $sortfun = null) {
+        $this->sortfun = $sortfun ?? fn(&$x) => asort($x);
+    }
+
+    /**
      * Get student feedback.
      *
      * @param array $data
@@ -114,8 +130,7 @@ class customscalefeedback extends feedbackgenerator {
             return null;
         }
 
-        // Todo: make the sorting dependent on the strategy!
-        asort($personabilities);
+        ($this->sortfun)($personabilities);
 
         $scalefeedback = [];
         foreach ($personabilities as $catscaleid => $personability) {

--- a/classes/teststrategy/strategy/classicalcat.php
+++ b/classes/teststrategy/strategy/classicalcat.php
@@ -85,12 +85,12 @@ class classicalcat extends strategy {
      */
     public function get_feedbackgenerators(): array {
         return [
-            comparetotestaverage::class,
-            customscalefeedback::class,
-            debuginfo::class,
-            personabilities::class,
-            questionssummary::class,
-            graphicalsummary::class,
+            new comparetotestaverage(),
+            new customscalefeedback(),
+            new debuginfo(),
+            new personabilities(),
+            new questionssummary(),
+            new graphicalsummary(),
         ];
     }
 }

--- a/classes/teststrategy/strategy/inferallsubscales.php
+++ b/classes/teststrategy/strategy/inferallsubscales.php
@@ -92,12 +92,12 @@ class inferallsubscales extends strategy {
      */
     public function get_feedbackgenerators(): array {
         return [
-            questionssummary::class,
-            personabilities::class,
-            comparetotestaverage::class,
-            customscalefeedback::class,
-            debuginfo::class,
-            graphicalsummary::class,
+            new questionssummary(),
+            new personabilities(),
+            new comparetotestaverage(),
+            new customscalefeedback(),
+            new debuginfo(),
+            new graphicalsummary(),
         ];
     }
 }

--- a/classes/teststrategy/strategy/infergreateststrength.php
+++ b/classes/teststrategy/strategy/infergreateststrength.php
@@ -94,13 +94,13 @@ class infergreateststrength extends strategy {
      */
     public function get_feedbackgenerators(): array {
         return [
-            questionssummary::class,
-            personabilities::class,
-            pilotquestions::class,
-            customscalefeedback::class,
-            comparetotestaverage::class,
-            debuginfo::class,
-            graphicalsummary::class,
+            new questionssummary(),
+            new personabilities(),
+            new pilotquestions(),
+            new customscalefeedback(fn(&$x) => arsort($x)),
+            new comparetotestaverage(),
+            new debuginfo(),
+            new graphicalsummary(),
         ];
     }
 }

--- a/classes/teststrategy/strategy/inferlowestskillgap.php
+++ b/classes/teststrategy/strategy/inferlowestskillgap.php
@@ -95,12 +95,12 @@ class inferlowestskillgap extends strategy {
      */
     public function get_feedbackgenerators(): array {
         return [
-            comparetotestaverage::class,
-            customscalefeedback::class,
-            debuginfo::class,
-            personabilities::class,
-            questionssummary::class,
-            graphicalsummary::class,
+            new comparetotestaverage(),
+            new customscalefeedback(),
+            new debuginfo(),
+            new personabilities(),
+            new questionssummary(),
+            new graphicalsummary(),
         ];
     }
 }

--- a/classes/teststrategy/strategy/teststrategy_balanced.php
+++ b/classes/teststrategy/strategy/teststrategy_balanced.php
@@ -82,11 +82,11 @@ class teststrategy_balanced extends strategy {
      */
     public function get_feedbackgenerators(): array {
         return [
-            questionssummary::class,
-            personabilities::class,
-            pilotquestions::class,
-            debuginfo::class,
-            graphicalsummary::class,
+          new   questionssummary(),
+          new   personabilities(),
+          new   pilotquestions(),
+          new   debuginfo(),
+          new   graphicalsummary(),
         ];
     }
 }

--- a/classes/teststrategy/strategy/teststrategy_fastest.php
+++ b/classes/teststrategy/strategy/teststrategy_fastest.php
@@ -87,12 +87,12 @@ class teststrategy_fastest extends strategy {
      */
     public function get_feedbackgenerators(): array {
         return [
-            questionssummary::class,
-            personabilities::class,
-            comparetotestaverage::class,
-            customscalefeedback::class,
-            debuginfo::class,
-            graphicalsummary::class,
+            new questionssummary(),
+            new personabilities(),
+            new comparetotestaverage(),
+            new customscalefeedback(),
+            new debuginfo(),
+            new graphicalsummary(),
         ];
     }
 }


### PR DESCRIPTION
This is more of a minimal example of how feedback generators can be configured on a per-strategy basis: by passing parameters via the constructor argument.
This is implemented here for the `customscalefeedback` class. If no argument is given, feedbacks are sorted by ascending person ability. However, this can be changed by passing a custom sort function, as for the `infergreateststrength` strategy.

Closes #184 