### PR TITLE
Quickfix: remove cached questions for feedback

### DIFF
--- a/classes/teststrategy/feedbackgenerator/debuginfo.php
+++ b/classes/teststrategy/feedbackgenerator/debuginfo.php
@@ -101,19 +101,13 @@ class debuginfo extends feedbackgenerator {
             if (! $lastquestion) {
                 $rowarr[] = 'NA';
             } else {
-                $id = $lastquestion['id'] ?? 'NA';
-                $score = $lastquestion['score'] ?? 'NA';
-                $fisherinformation = $lastquestion['fisherinformation'] ?? 'NA';
-                $lasttimeplayedpenalty = $lastquestion['lasttimeplayedpenalty'] ?? 'NA';
-                $difficulty = $lastquestion['difficulty'] ?? 'NA';
-                $fraction = $lastquestion['fraction'] ?? 'NA';
                 $rowarr[] =
-                "id: $id,
-                score: $score,
-                fisherinformation: $fisherinformation,
-                lasttimeplayedpenalty: $lasttimeplayedpenalty,
-                difficulty: $difficulty,
-                fraction: $fraction";
+                "id: " . $lastquestion['id']
+                .", score: " . $lastquestion['score']
+                .", fisherinformation: " . $lastquestion['fisherinformation'] ?? 'NA'
+                .", lasttimeplayedpenalty: " . $lastquestion['lasttimeplayedpenalty'] ?? 'NA'
+                .", difficulty: " . $lastquestion['difficulty']
+                .", fraction: " . $lastquestion['fraction'];
             }
 
             $questions = $row['questions'];

--- a/classes/teststrategy/feedbackgenerator/debuginfo.php
+++ b/classes/teststrategy/feedbackgenerator/debuginfo.php
@@ -243,23 +243,25 @@ class debuginfo extends feedbackgenerator {
 
             $questions = [];
             $questionsperscale = [];
-            foreach ($data['questions'] as $qid => $question) {
-                $fisherinformation = $question->fisherinformation ?? "NA";
-                $score = $question->score ?? "NA";
-                $questions[] = [
-                    'id' => $qid,
-                    'text' => $question->questiontext,
-                    'type' => $question->qtype,
-                    'fisherinformation' => $fisherinformation,
-                    'score' => $score,
-                ];
-                if (! array_key_exists($question->catscaleid, $questionsperscale)) {
-                    $questionsperscale[$question->catscaleid] = [
-                        'num' => 0,
-                        'name' => $catscales[$question->catscaleid]->name,
+            if (array_key_exists('questions', $data)) {
+                foreach ($data['questions'] as $qid => $question) {
+                    $fisherinformation = $question->fisherinformation ?? "NA";
+                    $score = $question->score ?? "NA";
+                    $questions[] = [
+                        'id' => $qid,
+                        'text' => $question->questiontext,
+                        'type' => $question->qtype,
+                        'fisherinformation' => $fisherinformation,
+                        'score' => $score,
                     ];
+                    if (! array_key_exists($question->catscaleid, $questionsperscale)) {
+                        $questionsperscale[$question->catscaleid] = [
+                            'num' => 0,
+                            'name' => $catscales[$question->catscaleid]->name,
+                        ];
+                    }
+                    $questionsperscale[$question->catscaleid]['num'] = $questionsperscale[$question->catscaleid]['num'] + 1;
                 }
-                $questionsperscale[$question->catscaleid]['num'] = $questionsperscale[$question->catscaleid]['num'] + 1;
             }
             if ($questions) {
                 $questions[array_key_last($questions)]['last'] = true;

--- a/classes/teststrategy/feedbackgenerator/graphicalsummary.php
+++ b/classes/teststrategy/feedbackgenerator/graphicalsummary.php
@@ -136,12 +136,16 @@ class graphicalsummary extends feedbackgenerator {
             )->name;
             $graphicalsummary[$index - 1]['fisherinformation'] = $lastquestion->fisherinformation ?? null;
             $graphicalsummary[$index - 1]['score'] = $lastquestion->score ?? null;
-            [$before, $after] = $this->getneighborquestions(
-                $lastquestion,
-                $cachedcontexts[$index - 1]['questions']
-            );
-            $graphicalsummary[$index - 1]['difficultynextbefore'] = $before->difficulty;
-            $graphicalsummary[$index - 1]['difficultynextafter'] = $after->difficulty;
+            $before = null;
+            $after = null;
+            if (array_key_exists('questions', $cachedcontexts[$index - 1])) {
+                [$before, $after] = $this->getneighborquestions(
+                    $lastquestion,
+                    $cachedcontexts[$index - 1]['questions']
+                );
+            }
+            $graphicalsummary[$index - 1]['difficultynextbefore'] = $before->difficulty ?? null;
+            $graphicalsummary[$index - 1]['difficultynextafter'] = $after->difficulty ?? null;
             $graphicalsummary[$index - 1]['personability_after'] = $data['person_ability'][$data['catscaleid']];
             $graphicalsummary[$index - 1]['personability_before'] =
                 $cachedcontexts[$index - 1]['person_ability'][$data['catscaleid']];

--- a/classes/wb_middleware_runner.php
+++ b/classes/wb_middleware_runner.php
@@ -67,6 +67,8 @@ class wb_middleware_runner {
                 if ($cache) {
                     $cachedcontexts = $cache->get('context') ?: [];
                     $cachedcontexts[$context['questionsattempted']] = $context;
+                    unset($cachedcontexts[$context['questionsattempted']]['original_questions']);
+                    unset($cachedcontexts[$context['questionsattempted']]['questions']);
                     $cache->set('context', $cachedcontexts);
                 }
                 return $result;


### PR DESCRIPTION
To prevent exhausting the memory, this removes both the `questions` and `original_questions` elements from the `$context` that is saved for each response during a quiz attempt. 

This means that now some data are missing in the debuginfo CSV output