### PR TITLE
Throw exception if catscale can not be found

### DIFF
--- a/classes/catscale.php
+++ b/classes/catscale.php
@@ -84,7 +84,10 @@ class catscale {
         if ($catscale = $cache->get($catscaleid)) {
             return $catscale;
         }
-        $catscale = $DB->get_record('local_catquiz_catscales', ['id' => $catscaleid]) ?: null;
+        $catscale = $DB->get_record('local_catquiz_catscales', ['id' => $catscaleid]);
+        if (! $catscale) {
+            throw new \Exception(sprintf('Could not find a scale with ID %s', $catscaleid));
+        }
         $cache->set($catscaleid, $catscale);
         return $catscale;
     }
@@ -142,18 +145,16 @@ class catscale {
      */
     public static function return_default_contextid_of_catscale(int $catscaleid) {
 
-        $catscale = self::return_catscale_object($catscaleid);
-        if (!empty($catscale) && isset($catscale->contextid)) {
-            return intval($catscale->contextid);
-        } else {
+        try {
+            $catscale = self::return_catscale_object($catscaleid);
+            if (isset($catscale->contextid)) {
+                return intval($catscale->contextid);
+            } else {
+                return null;
+            }
+        } catch (\Exception $e) {
             return null;
         }
-
-        $catscale = self::return_catscale_object($catscaleid);
-        if (!$catscale) {
-            return null;
-        }
-        return $catscale->contextid;
     }
 
     /**
@@ -567,18 +568,19 @@ class catscale {
      */
     public static function get_link_to_catscale(int $catscaleid, $url = '/local/catquiz/manage_catscales.php') {
 
-        $catscale = self::return_catscale_object($catscaleid);
-        if (!empty($catscale->name)) {
-            $catscalename = $catscale->name;
+        try {
+            $catscale = self::return_catscale_object($catscaleid);
+            if (!empty($catscale->name)) {
+                $catscalename = $catscale->name;
 
-            $url = new moodle_url($url, ['scaleid' => $catscaleid], 'lcq_catscales');
-            $linktoscale = html_writer::link($url, $catscalename);
+                $url = new moodle_url($url, ['scaleid' => $catscaleid], 'lcq_catscales');
+                $linktoscale = html_writer::link($url, $catscalename);
 
-            return $linktoscale;
-        } else {
+                return $linktoscale;
+            }
+        } catch (\Exception $e) {
             return get_string("deletedcatscale", "local_catquiz");
         }
-
     }
 
     /**


### PR DESCRIPTION
If we lookup a catscale with a certain ID and there is none, raise an exception instead of returning null.

This prevents us from having to check if a catscale is null everytime we use the `return_catscale_object()` function.
Instead, the code that uses it can wrap the call within a try/catch block.
If we accidentally forget to do that, the exception message should make it easier to find the error.