### PR TITLE
Add more information to exception

### DIFF
--- a/classes/teststrategy/preselect_task/updatepersonability.php
+++ b/classes/teststrategy/preselect_task/updatepersonability.php
@@ -25,6 +25,7 @@
 namespace local_catquiz\teststrategy\preselect_task;
 
 use cache;
+use Exception;
 use local_catquiz\catcalc;
 use local_catquiz\catcontext;
 use local_catquiz\catquiz;
@@ -200,13 +201,24 @@ class updatepersonability extends preselect_task implements wb_middleware {
             $startvalue = $parentability;
         }
 
-        $updatedability = catcalc::estimate_person_ability(
-            $this->arrayresponses,
-            $itemparamlist,
-            $startvalue,
-            $this->parentability,
-            $this->parentse
-        );
+        try {
+            $updatedability = catcalc::estimate_person_ability(
+                $this->arrayresponses,
+                $itemparamlist,
+                $startvalue,
+                $this->parentability,
+                $this->parentse
+            );
+        } catch (moodle_exception $e) {
+            // If we get an excpetion, re-throw it with more information.
+            $message = sprintf(
+                'Can not update ability for scale %d in context %d: %s',
+                $catscaleid,
+                catscale::get_context_id($catscaleid),
+                $e->getMessage()
+            );
+            throw new Exception($message);
+        }
 
         if (is_nan($updatedability)) {
             // In a production environment, we can use fallback values. However,


### PR DESCRIPTION
This adds more information to the exception that is thrown if the ability can not be calculated due to missing item params.

This should help to debug #272 


![image](https://github.com/Wunderbyte-GmbH/moodle-local_catquiz/assets/17564611/0e90bcdb-e4d9-4be7-ab9b-cfade3a8511d)
