### PR TITLE
Show message if quiz can not be started

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -1314,7 +1314,7 @@ class catquiz {
             throw new moodle_exception("Can not read test settings");
         }
 
-        $contextid = intval($testsettings->catquiz_catcontext);
+        $contextid = catscale::get_context_id($testsettings->catquiz_catscales);
         $catscaleids = explode(",", $testsettings->catquiz_catscales);
         [$insql, $inparams] = $DB->get_in_or_equal($catscaleids, SQL_PARAMS_NAMED, 'incatscales');
 

--- a/classes/catquiz_handler.php
+++ b/classes/catquiz_handler.php
@@ -800,6 +800,11 @@ class catquiz_handler {
         global $OUTPUT, $COURSE;
         $contextid = optional_param('context', 0, PARAM_INT);
 
+        $cache = cache::make('local_catquiz', 'adaptivequizattempt');
+        if (($errormsg = $cache->get('catquizerror')) && $attemptrecord->questionsattempted == 0) {
+            return get_string($errormsg, 'local_catquiz');
+        }
+
         $attemptfeedback = new attemptfeedback($attemptrecord->id, $contextid, null, $COURSE->id);
         $data = $attemptfeedback->export_for_template($OUTPUT);
 

--- a/classes/local/status.php
+++ b/classes/local/status.php
@@ -84,4 +84,13 @@ class status {
      * @var string
      */
     const ERROR_EMPTY_FIRST_QUESTION_LIST = 'emptyfirstquestionlist';
+
+    /**
+     * ERROR_NO_ITEMS
+     *
+     * There are no item params for the given context/catscale.
+     *
+     * @var string
+     */
+    const ERROR_NO_ITEMS = 'errornoitems';
 }

--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -151,6 +151,7 @@ class attemptfeedback implements renderable, templatable {
             'total_number_of_testitems' => $cache->get('totalnumberoftestitems'),
             'number_of_testitems_used' => empty($cache->get('playedquestions')) ? 0 : count($cache->get('playedquestions')),
             'ability_before_attempt' => $cache->get('abilitybeforeattempt'),
+            'catquizerror' => $cache->get('catquizerror'),
             'studentfeedback' => [],
             'teacherfeedback' => [],
             'quizsettings' => $cache->get('quizsettings'),

--- a/classes/teststrategy/preselect_task/checkitemparams.php
+++ b/classes/teststrategy/preselect_task/checkitemparams.php
@@ -1,0 +1,86 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Class checkitemparams.
+ *
+ * @package local_catquiz
+ * @copyright 2023 Wunderbyte GmbH
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_catquiz\teststrategy\preselect_task;
+
+use local_catquiz\catscale;
+use local_catquiz\local\model\model_item_param_list;
+use local_catquiz\local\model\model_strategy;
+use local_catquiz\local\result;
+use local_catquiz\local\status;
+use local_catquiz\teststrategy\preselect_task;
+use local_catquiz\wb_middleware;
+
+/**
+ * Checks if there are item parameters for the given combination of scale and context.
+ *
+ * @package local_catquiz
+ * @copyright 2023 Wunderbyte GmbH
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class checkitemparams extends preselect_task implements wb_middleware {
+
+    /**
+     * Run.
+     *
+     * @param array $context
+     * @param callable $next
+     *
+     * @return result
+     *
+     */
+    public function run(array &$context, callable $next): result {
+        foreach ($context['selectedsubscales'] as $catscaleid) {
+            $catscalecontext = catscale::get_context_id($catscaleid);
+            $catscaleids = [
+                $catscaleid,
+                ...catscale::get_subscale_ids($catscaleid),
+            ];
+            $itemparamlists = [];
+            foreach (array_keys(model_strategy::get_installed_models()) as $model) {
+                $itemparamlists[$model] = count(model_item_param_list::load_from_db(
+                    $catscalecontext,
+                    $model,
+                    $catscaleids
+                ));
+            }
+            if (array_sum($itemparamlists) === 0) {
+                return result::err(status::ERROR_NO_ITEMS);
+            }
+        }
+        return $next($context);
+    }
+
+    /**
+     * Get required context keys.
+     *
+     * @return array
+     *
+     */
+    public function get_required_context_keys(): array {
+        return [
+            'selectedsubscales',
+        ];
+    }
+}

--- a/classes/teststrategy/strategy.php
+++ b/classes/teststrategy/strategy.php
@@ -135,6 +135,7 @@ abstract class strategy {
         if ($result->isErr()) {
             $cache->set('stopreason', $result->get_status());
             $cache->set('endtime', time());
+            $cache->set('catquizerror', $result->get_status());
             return $result;
         }
 

--- a/classes/teststrategy/strategy/classicalcat.php
+++ b/classes/teststrategy/strategy/classicalcat.php
@@ -32,6 +32,7 @@ use local_catquiz\teststrategy\feedbackgenerator\personabilities;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
 use local_catquiz\teststrategy\preselect_task\maximumquestionscheck;
 use local_catquiz\teststrategy\preselect_task\mayberemovescale;
@@ -71,6 +72,7 @@ class classicalcat extends strategy {
      */
     public function get_preselecttasks(): array {
         return [
+            checkitemparams::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class,

--- a/classes/teststrategy/strategy/inferallsubscales.php
+++ b/classes/teststrategy/strategy/inferallsubscales.php
@@ -32,6 +32,7 @@ use local_catquiz\teststrategy\feedbackgenerator\personabilities;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
@@ -75,6 +76,7 @@ class inferallsubscales extends strategy {
      */
     public function get_preselecttasks(): array {
         return [
+            checkitemparams::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.

--- a/classes/teststrategy/strategy/infergreateststrength.php
+++ b/classes/teststrategy/strategy/infergreateststrength.php
@@ -33,6 +33,7 @@ use local_catquiz\teststrategy\feedbackgenerator\pilotquestions;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
 use local_catquiz\teststrategy\preselect_task\filterforsubscale;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
@@ -77,6 +78,7 @@ class infergreateststrength extends strategy {
      */
     public function get_preselecttasks(): array {
         return [
+            checkitemparams::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.
             updatepersonability::class,
             removeplayedquestions::class,

--- a/classes/teststrategy/strategy/inferlowestskillgap.php
+++ b/classes/teststrategy/strategy/inferlowestskillgap.php
@@ -32,6 +32,7 @@ use local_catquiz\teststrategy\feedbackgenerator\personabilities;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
@@ -75,6 +76,7 @@ class inferlowestskillgap extends strategy {
      */
     public function get_preselecttasks(): array {
         return [
+            checkitemparams::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.

--- a/classes/teststrategy/strategy/teststrategy_balanced.php
+++ b/classes/teststrategy/strategy/teststrategy_balanced.php
@@ -32,6 +32,7 @@ use local_catquiz\teststrategy\feedbackgenerator\pilotquestions;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
 use local_catquiz\teststrategy\preselect_task\lasttimeplayedpenalty;
 use local_catquiz\teststrategy\preselect_task\maximumquestionscheck;
@@ -72,6 +73,7 @@ class teststrategy_balanced extends strategy {
      */
     public function get_preselecttasks(): array {
         return [
+            checkitemparams::class,
             maximumquestionscheck::class,
             updatepersonability::class,
             mayberemovescale::class,

--- a/classes/teststrategy/strategy/teststrategy_fastest.php
+++ b/classes/teststrategy/strategy/teststrategy_fastest.php
@@ -32,6 +32,7 @@ use local_catquiz\teststrategy\feedbackgenerator\personabilities;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
 use local_catquiz\teststrategy\preselect_task\lasttimeplayedpenalty;
@@ -74,6 +75,7 @@ class teststrategy_fastest extends strategy {
      */
     public function get_preselecttasks(): array {
         return [
+            checkitemparams::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class,

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -400,6 +400,7 @@ $string['error'] = "Es ist ein Fehler aufgetreten";
 $string['id'] = "ID";
 $string['abortpersonabilitynotchanged'] = "Personenparameter unverändert";
 $string['emptyfirstquestionlist'] = "Kann keine Startfrage wählen da die Liste leer ist";
+$string['errornoitems'] = "Für die angegebenen Settings kann das Quiz nicht ausgeführt werden. Bitte kontaktieren sie Ihren CAT Manager.";
 
 // Quiz Feedback.
 $string['attemptfeedbacknotavailable'] = "Kein Feedback verfügbar";

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -400,6 +400,7 @@ $string['id'] = "ID";
 $string['abortpersonabilitynotchanged'] = "Person parameter did not change";
 $string['emptyfirstquestionlist'] = "Can't select a start question because the list is empty";
 $string['feedbackcomparetoaverage'] = 'You performed better than {$a->quantile}% of your fellow students for {$a->scaleinfo}.';
+$string['errornoitems'] = "The quiz can not be started with the given settings. Please contact your CAT manager.";
 
 // Quiz Feedback.
 $string['attemptfeedbacknotavailable'] = "No feedback available";


### PR DESCRIPTION
Instead of going to the point where an exception is raised, this adds a new pre-select task `checkitemparams` to check if we could perform the quiz. If not, an error is returned.

The feedback was changed as follows:
if an error message is returned and 0 messages were attempted, show the error message.
Sometimes we get an error message even if the quiz was executed, e.g. because there are no more questions. In this case we want to show the normal quiz feedback. That's why the error message is displayed only if the quiz returned an error *and* no questions were attempted.

Related to #272 