### PR TITLE
Fix: add SE before stopping quiz

### DIFF
--- a/classes/teststrategy/strategy/infergreateststrength.php
+++ b/classes/teststrategy/strategy/infergreateststrength.php
@@ -79,9 +79,9 @@ class infergreateststrength extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
-            maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.
             updatepersonability::class,
             addscalestandarderror::class,
+            maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.
             removeplayedquestions::class,
             noremainingquestions::class,
             fisherinformation::class, // Add the fisher information to each question.

--- a/classes/teststrategy/strategy/teststrategy_balanced.php
+++ b/classes/teststrategy/strategy/teststrategy_balanced.php
@@ -74,9 +74,9 @@ class teststrategy_balanced extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
-            maximumquestionscheck::class,
             updatepersonability::class,
             addscalestandarderror::class,
+            maximumquestionscheck::class,
             mayberemovescale::class,
             noremainingquestions::class,
             lasttimeplayedpenalty::class,


### PR DESCRIPTION
This fixes errors about a missing standard error 'se' in the "infer greatest strength" and "balanced" teststrategies.