### PR TITLE
Dev david issue 311

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -1775,4 +1775,13 @@ class catquiz {
         }
         return true;
     }
+
+    /**
+     * Marks the given question as failed
+     *
+     * @param stdClass $question
+     */
+    public static function mark_question_failed(stdClass $question) {
+        throw new \Exception("Not yet implemented");
+    }
 }

--- a/classes/catquiz_handler.php
+++ b/classes/catquiz_handler.php
@@ -908,8 +908,8 @@ class catquiz_handler {
             'updateabilityfallback' => false,
             'excludedsubscales' => [],
             'has_fisherinformation' => false,
-            'max_attempttime_in_sec' => $attemptseconds ?? 0,
-            'max_itemtime_in_sec' => $itemseconds ?? 0,
+            'max_attempttime_in_sec' => $attemptseconds ?? INF,
+            'max_itemtime_in_sec' => $itemseconds ?? INF,
             'se_max' => $quizsettings->catquiz_standarderrorgroup->catquiz_standarderror_max,
             'se_min' => $quizsettings->catquiz_standarderrorgroup->catquiz_standarderror_min,
         ];

--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -139,7 +139,10 @@ class attemptfeedback implements renderable, templatable {
      */
     public function update_feedbackdata(array $newdata = []) {
         $progress = $newdata['progress'];
-        if (!$progress->has_new_response()) {
+        if (
+            $progress->get_ignore_last_response()
+            || (!$progress->is_first_question() && !$progress->has_new_response() && !$progress->get_force_new_question())
+        ) {
             return;
         }
         $existingdata = $this->load_feedbackdata();

--- a/classes/teststrategy/context/loader/questions_loader.php
+++ b/classes/teststrategy/context/loader/questions_loader.php
@@ -88,6 +88,11 @@ class questions_loader implements contextloaderinterface {
         $context['questions_ordered_by'] = 'difficulty';
         $context['original_questions'] = $context['questions'];
 
+        // Some questions can be manually excluded, e.g. when the time limit is exceeded.
+        foreach ($this->progress->get_excluded_questions() as $excludedqid) {
+            unset($context['questions'][$excludedqid]);
+        }
+
         $cache = cache::make('local_catquiz', 'adaptivequizattempt');
         if ($this->progress->is_first_question()) {
             $cache->set('totalnumberoftestitems', count($context['questions']));

--- a/classes/teststrategy/info.php
+++ b/classes/teststrategy/info.php
@@ -346,16 +346,6 @@ class info {
         $mform->setType('catquiz_maxtimeperitem', PARAM_INT);
         $mform->hideIf('catquiz_timelimitgroup', 'catquiz_includetimelimit', 'neq', 1);
 
-        $timeoutoptions = [
-            1 => get_string('timeoutfinishwithresult', 'local_catquiz'),
-            2 => get_string('timeoutabortresult', 'local_catquiz'),
-            3 => get_string('timeoutabortnoresult', 'local_catquiz'),
-        ];
-        // Choose a model for this instance.
-        $elements[] = $mform->addElement('select', 'catquiz_actontimeout',
-        get_string('actontimeout', 'local_catquiz'), $timeoutoptions);
-        $mform->hideIf('catquiz_actontimeout', 'catquiz_includetimelimit', 'neq', 1);
-
         feedbackclass::instance_form_definition($mform, $elements);
     }
 

--- a/classes/teststrategy/preselect_task.php
+++ b/classes/teststrategy/preselect_task.php
@@ -81,13 +81,6 @@ abstract class preselect_task implements wb_middleware {
     }
 
     /**
-     * Call the next preselect task with $this->context
-     */
-    public function next() {
-        return ($this->nexttask)($this->context);
-    }
-
-    /**
      * This is the function in which the $context can be modified.
      *
      * To return early and skip the rest of the middleware chain, return a result directly.

--- a/classes/teststrategy/preselect_task/checkbreak.php
+++ b/classes/teststrategy/preselect_task/checkbreak.php
@@ -68,8 +68,9 @@ final class checkbreak extends preselect_task implements wb_middleware {
             redirect($breakinfourl);
         }
 
-        $lastquestionreturntime = $this->progress->get_last_question()->userlastattempttime;
-        if (!$lastquestionreturntime || $now - $lastquestionreturntime <= $context['maxtimeperquestion']) {
+        $lastquestion = $this->progress->get_last_question();
+        $lastquestionreturntime = $lastquestion->userlastattempttime;
+        if (!$lastquestionreturntime || $now - $lastquestionreturntime <= $context['max_itemtime_in_sec']) {
             return $next($context);
         }
 
@@ -79,7 +80,7 @@ final class checkbreak extends preselect_task implements wb_middleware {
 
         // If the session is not the same as when the quiz was started, just ignore that last question.
         if (!$this->progress->check_session()) {
-            $this->progress->exclude_question($this->progress->get_last_question()->id);
+            $this->progress->exclude_question($lastquestion->id);
             return $next($context);
         }
 
@@ -96,9 +97,7 @@ final class checkbreak extends preselect_task implements wb_middleware {
      */
     public function get_required_context_keys(): array {
         return [
-            'breakduration',
-            'breakinfourl',
-            'maxtimeperquestion',
+            'max_itemtime_in_sec',
             'progress',
         ];
     }

--- a/classes/teststrategy/preselect_task/checkbreak.php
+++ b/classes/teststrategy/preselect_task/checkbreak.php
@@ -78,6 +78,7 @@ final class checkbreak extends preselect_task implements wb_middleware {
                 ->exclude_question($lastquestion->id)
                 ->force_new_question()
                 ->set_ignore_last_response(true);
+            unset($context['questions'][$lastquestion->id]);
             return $next($context);
         }
 

--- a/classes/teststrategy/preselect_task/checkpagereload.php
+++ b/classes/teststrategy/preselect_task/checkpagereload.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Class checkpagereload.
+ *
+ * @package local_catquiz
+ * @copyright 2023 Wunderbyte GmbH
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_catquiz\teststrategy\preselect_task;
+
+use local_catquiz\local\result;
+use local_catquiz\teststrategy\preselect_task;
+use local_catquiz\teststrategy\progress;
+use local_catquiz\wb_middleware;
+
+/**
+ * Checks if we have a new response. If not, presents the previous question again.
+ *
+ * @package local_catquiz
+ * @copyright 2023 Wunderbyte GmbH
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class checkpagereload extends preselect_task implements wb_middleware {
+
+    /**
+     * @var progress $progress
+     */
+    private progress $progress;
+
+    /**
+     * Run.
+     *
+     * @param array $context
+     * @param callable $next
+     *
+     * @return result
+     *
+     */
+    public function run(array &$context, callable $next): result {
+        $this->progress = $context['progress'];
+        if (($this->progress->is_first_question() && !$this->progress->get_last_question())
+            || $this->progress->has_new_response()
+        ) {
+            return $next($context);
+        }
+
+        return result::ok($this->progress->get_last_question());
+    }
+
+    public function get_required_context_keys(): array {
+        return ['progress'];
+    }
+}

--- a/classes/teststrategy/preselect_task/checkpagereload.php
+++ b/classes/teststrategy/preselect_task/checkpagereload.php
@@ -56,6 +56,7 @@ final class checkpagereload extends preselect_task implements wb_middleware {
         $this->progress = $context['progress'];
         if (($this->progress->is_first_question() && !$this->progress->get_last_question())
             || $this->progress->has_new_response()
+            || $this->progress->get_force_new_question()
         ) {
             return $next($context);
         }

--- a/classes/teststrategy/preselect_task/filterbystandarderror.php
+++ b/classes/teststrategy/preselect_task/filterbystandarderror.php
@@ -65,11 +65,11 @@ class filterbystandarderror extends preselect_task implements wb_middleware {
             // If this is the first question and the cache is not yet set, set the
             // root scale active.
             $this->progress->set_active_scales([$this->context['catscaleid']]);
-            return $this->next();
+            return $next($context);
         }
 
         if (!$this->progress->has_new_response()) {
-            return $this->next();
+            return $next($context);
         }
 
         $lastquestion = $this->progress->get_last_question();
@@ -186,7 +186,7 @@ class filterbystandarderror extends preselect_task implements wb_middleware {
 
         }
 
-        return $this->next();
+        return $next($context);
     }
 
     /**

--- a/classes/teststrategy/preselect_task/filterbystandarderror.php
+++ b/classes/teststrategy/preselect_task/filterbystandarderror.php
@@ -60,16 +60,19 @@ class filterbystandarderror extends preselect_task implements wb_middleware {
      */
     public function run(array &$context, callable $next): result {
         $this->progress = $context['progress'];
-        $cache = cache::make('local_catquiz', 'adaptivequizattempt');
 
-        $lastquestion = $this->progress->get_last_question();
-        if (!$lastquestion) {
+        if ($this->progress->is_first_question()) {
             // If this is the first question and the cache is not yet set, set the
             // root scale active.
             $this->progress->set_active_scales([$this->context['catscaleid']]);
             return $this->next();
         }
 
+        if (!$this->progress->has_new_response()) {
+            return $this->next();
+        }
+
+        $lastquestion = $this->progress->get_last_question();
         $scaleid = $lastquestion->catscaleid;
         $updatedscales = [$scaleid, ...catscale::get_ancestors($scaleid)];
         foreach ($updatedscales as $scaleid) {

--- a/classes/teststrategy/preselect_task/maximumquestionscheck.php
+++ b/classes/teststrategy/preselect_task/maximumquestionscheck.php
@@ -56,6 +56,12 @@ final class maximumquestionscheck extends preselect_task implements wb_middlewar
      */
     public function run(array &$context, callable $next): result {
         $this->progress = $context['progress'];
+
+        // No need for this check after a page reload.
+        if (!$this->progress->has_new_response()) {
+            return $this->next();
+        }
+
         $maxquestions = $context['maximumquestions'];
         if (($maxquestions != -1) && ($context['questionsattempted'] >= $maxquestions)) {
             // Save the last response so that we can display it as feedback.

--- a/classes/teststrategy/preselect_task/maximumquestionscheck.php
+++ b/classes/teststrategy/preselect_task/maximumquestionscheck.php
@@ -57,10 +57,10 @@ final class maximumquestionscheck extends preselect_task implements wb_middlewar
     public function run(array &$context, callable $next): result {
         $this->progress = $context['progress'];
 
-        // No need for this check after a page reload.
-        if (!$this->progress->has_new_response()) {
-            return $next($context);
-        }
+        // // No need for this check after a page reload.
+        // if (!$this->progress->has_new_response()) {
+        //     return $next($context);
+        // }
 
         $maxquestions = $context['maximumquestions'];
         if (($maxquestions != -1) && ($context['questionsattempted'] >= $maxquestions)) {

--- a/classes/teststrategy/preselect_task/maximumquestionscheck.php
+++ b/classes/teststrategy/preselect_task/maximumquestionscheck.php
@@ -57,11 +57,6 @@ final class maximumquestionscheck extends preselect_task implements wb_middlewar
     public function run(array &$context, callable $next): result {
         $this->progress = $context['progress'];
 
-        // // No need for this check after a page reload.
-        // if (!$this->progress->has_new_response()) {
-        //     return $next($context);
-        // }
-
         $maxquestions = $context['maximumquestions'];
         if (($maxquestions != -1) && ($context['questionsattempted'] >= $maxquestions)) {
             // Save the last response so that we can display it as feedback.

--- a/classes/teststrategy/preselect_task/maximumquestionscheck.php
+++ b/classes/teststrategy/preselect_task/maximumquestionscheck.php
@@ -59,7 +59,7 @@ final class maximumquestionscheck extends preselect_task implements wb_middlewar
 
         // No need for this check after a page reload.
         if (!$this->progress->has_new_response()) {
-            return $this->next();
+            return $next($context);
         }
 
         $maxquestions = $context['maximumquestions'];

--- a/classes/teststrategy/preselect_task/updatepersonability.php
+++ b/classes/teststrategy/preselect_task/updatepersonability.php
@@ -119,11 +119,12 @@ class updatepersonability extends preselect_task implements wb_middleware {
         $this->initialse = $this->get_initial_standarderror();
         $this->parentability = $this->initialability;
         $this->parentse = $this->initialse;
+
         // If we do not know the answer to the last question, we do not have to
         // update the person ability. Also, pilot questions should not be used
         // to update a student's ability.
         if ($this->progress->is_first_question()
-            || $this->progress->get_last_question() === null) {
+            || !$this->progress->has_new_response()) {
             $context['skip_reason'] = 'lastquestionnull';
             return $next($context);
 

--- a/classes/teststrategy/preselect_task/updatepersonability.php
+++ b/classes/teststrategy/preselect_task/updatepersonability.php
@@ -123,11 +123,14 @@ class updatepersonability extends preselect_task implements wb_middleware {
         // If we do not know the answer to the last question, we do not have to
         // update the person ability. Also, pilot questions should not be used
         // to update a student's ability.
-        if ($this->progress->is_first_question()
-            || !$this->progress->has_new_response()) {
+        if (
+            $this->progress->get_ignore_last_response()
+            || (($this->progress->is_first_question() || !$this->progress->has_new_response())
+                && !$this->progress->get_force_new_question()
+            )
+        ) {
             $context['skip_reason'] = 'lastquestionnull';
             return $next($context);
-
         }
 
         $this->userresponses = (new model_responses())->setdata(

--- a/classes/teststrategy/progress.php
+++ b/classes/teststrategy/progress.php
@@ -34,8 +34,9 @@ use Random\RandomException;
 use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
+// No login check is expected here because this is already done in the
+// adaptivequiz attempt.php file. @codingStandardsIgnoreLine
 require_once(__DIR__ . '/../../../../config.php');
-// require_login();
 
 /**
  * Stores the progress of a catquiz attempt that is not yet finished.

--- a/classes/teststrategy/strategy.php
+++ b/classes/teststrategy/strategy.php
@@ -184,8 +184,12 @@ abstract class strategy {
         }
 
         // Do not update feedback data if the page was reloaded.
-        if (!$this->progress->is_first_question()
-            && !$this->progress->has_new_response()
+        if (
+            $this->progress->get_ignore_last_response()
+            || (!$this->progress->is_first_question()
+                && !$this->progress->has_new_response()
+                && !$this->progress->get_force_new_question()
+            )
         ) {
             return;
         }

--- a/classes/teststrategy/strategy.php
+++ b/classes/teststrategy/strategy.php
@@ -140,10 +140,9 @@ abstract class strategy {
         }
 
         $result = wb_middleware_runner::run($middlewares, $context);
+        $this->progress = $context['progress'];
 
         $this->update_attempdfeedback($context);
-
-        $this->progress = $context['progress'];
 
         $cache = cache::make('local_catquiz', 'adaptivequizattempt');
         if ($result->isErr()) {
@@ -183,6 +182,14 @@ abstract class strategy {
         if (getenv('CATQUIZ_TESTING_SKIP_FEEDBACK')) {
             return;
         }
+
+        // Do not update feedback data if the page was reloaded.
+        if (!$this->progress->is_first_question()
+            && !$this->progress->has_new_response()
+        ) {
+            return;
+        }
+
         $attemptfeedback = new attemptfeedback($context['attemptid'], $context['contextid']);
         $attemptfeedback->update_feedbackdata($context);
     }

--- a/classes/teststrategy/strategy/classicalcat.php
+++ b/classes/teststrategy/strategy/classicalcat.php
@@ -33,6 +33,7 @@ use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
+use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
 use local_catquiz\teststrategy\preselect_task\maximumquestionscheck;
 use local_catquiz\teststrategy\preselect_task\mayberemovescale;
@@ -73,6 +74,7 @@ class classicalcat extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
+            checkpagereload::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class,

--- a/classes/teststrategy/strategy/inferallsubscales.php
+++ b/classes/teststrategy/strategy/inferallsubscales.php
@@ -33,6 +33,7 @@ use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
+use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
@@ -77,6 +78,7 @@ class inferallsubscales extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
+            checkpagereload::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.

--- a/classes/teststrategy/strategy/infergreateststrength.php
+++ b/classes/teststrategy/strategy/infergreateststrength.php
@@ -34,6 +34,7 @@ use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
+use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
 use local_catquiz\teststrategy\preselect_task\filterforsubscale;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
@@ -79,6 +80,7 @@ class infergreateststrength extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
+            checkpagereload::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.

--- a/classes/teststrategy/strategy/inferlowestskillgap.php
+++ b/classes/teststrategy/strategy/inferlowestskillgap.php
@@ -33,6 +33,7 @@ use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
+use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
@@ -77,6 +78,7 @@ class inferlowestskillgap extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
+            checkpagereload::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.

--- a/classes/teststrategy/strategy/inferlowestskillgap.php
+++ b/classes/teststrategy/strategy/inferlowestskillgap.php
@@ -32,6 +32,7 @@ use local_catquiz\teststrategy\feedbackgenerator\personabilities;
 use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
+use local_catquiz\teststrategy\preselect_task\checkbreak;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
 use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\filterbystandarderror;
@@ -78,10 +79,11 @@ class inferlowestskillgap extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
-            checkpagereload::class,
+            checkbreak::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class, // Cancel quiz attempt if we reached maximum of questions.
+            checkpagereload::class, // This must be after maximumquestionscheck, so that the quiz ends.
             removeplayedquestions::class,
             noremainingquestions::class,
             fisherinformation::class, // Add the fisher information to each question.

--- a/classes/teststrategy/strategy/teststrategy_balanced.php
+++ b/classes/teststrategy/strategy/teststrategy_balanced.php
@@ -33,6 +33,7 @@ use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
+use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
 use local_catquiz\teststrategy\preselect_task\lasttimeplayedpenalty;
 use local_catquiz\teststrategy\preselect_task\maximumquestionscheck;
@@ -74,6 +75,7 @@ class teststrategy_balanced extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
+            checkpagereload::class,
             updatepersonability::class,
             addscalestandarderror::class,
             maximumquestionscheck::class,

--- a/classes/teststrategy/strategy/teststrategy_fastest.php
+++ b/classes/teststrategy/strategy/teststrategy_fastest.php
@@ -33,6 +33,7 @@ use local_catquiz\teststrategy\feedbackgenerator\questionssummary;
 use local_catquiz\teststrategy\feedbacksettings;
 use local_catquiz\teststrategy\preselect_task\addscalestandarderror;
 use local_catquiz\teststrategy\preselect_task\checkitemparams;
+use local_catquiz\teststrategy\preselect_task\checkpagereload;
 use local_catquiz\teststrategy\preselect_task\firstquestionselector;
 use local_catquiz\teststrategy\preselect_task\fisherinformation;
 use local_catquiz\teststrategy\preselect_task\lasttimeplayedpenalty;
@@ -76,6 +77,7 @@ class teststrategy_fastest extends strategy {
     public function get_preselecttasks(): array {
         return [
             checkitemparams::class,
+            checkpagereload::class,
             updatepersonability::class,
             fisherinformation::class,
             addscalestandarderror::class,

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -92,7 +92,6 @@ $string['includetimelimit_help'] = 'Maximaldauer festlegen, die für die Durchf�
 $string['maxtime'] = 'Maximale Dauer des Tests';
 $string['maxtimeperitem'] = 'Höchstzeit pro Frage in Sekunden';
 $string['mintimeperitem'] = 'Mindestzeit pro Frage in Sekunden';
-$string['actontimeout'] = 'Aktion nach Ablauf der Zeit';
 $string['perattempt'] = 'pro Versuch ';
 $string['peritem'] = 'pro Item ';
 

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -140,7 +140,6 @@ $string['startwithaverageabilityoftest'] = "Personenparamter entspricht Mittelwe
 $string['startwithcurrentability'] = "Personenparameter aus vorherigem Testlauf nutzen";
 $string['maxtimeperquestion'] = "Erlaubte Zeit";
 $string['maxtimeperquestion_help'] = "Falls die Beantwortung einer Frage länger dauert, wird eine Pause erzwungen";
-$string['breakduration'] = "Dauer der Pause in Sekunden";
 $string['min'] = "min:";
 $string['max'] = "max:";
 

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -82,7 +82,6 @@ $string['includetimelimit_help'] = 'Define a maximum duration for an attempt to 
 $string['maxtime'] = 'Max time for test';
 $string['maxtimeperitem'] = 'Max time per question in seconds';
 $string['mintimeperitem'] = 'Min time per question in seconds';
-$string['actontimeout'] = 'Action on timeout';
 $string['contextidselect'] = 'CAT context - without selection default context is created';
 $string['choosecontextid'] = 'Choose CAT context';
 $string['defaultcontext'] = 'New default context for scale';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -138,8 +138,6 @@ $string['startwithcurrentability'] = "Use the person's current ability score to 
 
 $string['maxtimeperquestion'] = "Maximum time";
 $string['maxtimeperquestion_help'] = "If the user takes longer to answer a question, a break will be enforced";
-$string['breakduration'] = "Duration of a forced break in seconds";
-
 // Tests environment.
 $string['newcustomtest'] = 'Custom test';
 $string['lang'] = 'Language';

--- a/tests/behat/catquiz_settings.feature
+++ b/tests/behat/catquiz_settings.feature
@@ -113,7 +113,6 @@ Feature: As a teacher I setup adaptive quiz with CATquiz Scales and Feedbacks.
       | Proportion of questions to be piloted in % | 20                        |
       | Start new CAT test with                    | Use the average ability score of the current test |
       | Limit time for attempt                     | 1                         |
-      | Action on timeout                          | Test aborted with result. |
       ## Intentional error - no time values
       ## Intentional error min > max
       | maxquestionsscalegroup[catquiz_minquestionspersubscale] | 3 |
@@ -176,7 +175,6 @@ Feature: As a teacher I setup adaptive quiz with CATquiz Scales and Feedbacks.
       | maxquestionsgroup[catquiz_minquestions]                 | 3   |
       | maxquestionsgroup[catquiz_maxquestions]                 | 10  |
       | Limit time for attempt                                  | 1   |
-      | Action on timeout                                       | Test aborted with result. |
       | catquiz_timelimitgroup[catquiz_maxtimeperattempt]       | 5   |
       | catquiz_timelimitgroup[catquiz_timeselect_attempt]      | min |
       | catquiz_timelimitgroup[catquiz_maxtimeperitem]          | 1   |

--- a/tests/teststrategy/preselect_task/updatepersonability_test.php
+++ b/tests/teststrategy/preselect_task/updatepersonability_test.php
@@ -103,7 +103,7 @@ class updatepersonability_test extends TestCase {
                 ],
                 'progress_fake_methods' => [
                     'is_first_question' => true,
-                ]
+                ],
             ],
             'is_pilot_question' => [
                 'expected' => 'pilotquestion',
@@ -115,7 +115,7 @@ class updatepersonability_test extends TestCase {
                     // Can be null here, because for pilot questions the ability will not be updated.
                     'fake_response_data' => [$USER->id => []],
                 ],
-                'progress_fake_methods' => []
+                'progress_fake_methods' => [],
             ],
             'has_enough_responses' => [
                 'expected' => 'not_skipped',
@@ -145,7 +145,7 @@ class updatepersonability_test extends TestCase {
                     'questionsattempted' => 0,
                     'minimumquestions' => 10,
                 ],
-                'progress_fake_methods' => []
+                'progress_fake_methods' => [],
             ],
         ];
     }

--- a/tests/teststrategy/preselect_task/updatepersonability_test.php
+++ b/tests/teststrategy/preselect_task/updatepersonability_test.php
@@ -52,13 +52,14 @@ class updatepersonability_test extends TestCase {
      * @param mixed $expected
      * @param mixed $lastquestion
      * @param mixed $context
+     * @param array $progressfakes
      *
      * @return mixed
      * @throws InvalidArgumentException
      * @throws ExpectationFailedException
      *
      */
-    public function test_ability_calculation_is_skipped_correctly($expected, $lastquestion, $context) {
+    public function test_ability_calculation_is_skipped_correctly($expected, $lastquestion, $context, $progressfakes) {
         global $USER;
         // We can not add a stub in the provider, so we do it here.
         $progressstub = $this->createStub(progress::class);
@@ -66,6 +67,12 @@ class updatepersonability_test extends TestCase {
             ->willReturn($lastquestion);
         $progressstub->method('get_user_responses')
             ->willReturn($context['fake_response_data'] ?? []);
+        $progressstub->method('has_new_response')
+            ->willReturn(true);
+        foreach ($progressfakes as $methodname => $returnval) {
+            $progressstub->method($methodname)
+                ->willReturn($returnval);
+        }
 
         $context['progress'] = $progressstub;
 
@@ -94,6 +101,9 @@ class updatepersonability_test extends TestCase {
                     'contextid' => 1,
                     'catscaleid' => 1,
                 ],
+                'progress_fake_methods' => [
+                    'is_first_question' => true,
+                ]
             ],
             'is_pilot_question' => [
                 'expected' => 'pilotquestion',
@@ -105,6 +115,7 @@ class updatepersonability_test extends TestCase {
                     // Can be null here, because for pilot questions the ability will not be updated.
                     'fake_response_data' => [$USER->id => []],
                 ],
+                'progress_fake_methods' => []
             ],
             'has_enough_responses' => [
                 'expected' => 'not_skipped',
@@ -134,6 +145,7 @@ class updatepersonability_test extends TestCase {
                     'questionsattempted' => 0,
                     'minimumquestions' => 10,
                 ],
+                'progress_fake_methods' => []
             ],
         ];
     }


### PR DESCRIPTION
Add code to handle
1. what happens when the maximum attempt time is exceeded for an item
2. what happens when the page is reloaded

depending on the user session, this leads to different results:

1. page is reloaded, question time not exceeded -> show the same question again
2. page is reloaded, question time is exceeded and the user session changed -> show a different question and do not count the previous one
3. page is reloaded, question time is exceeded and user is in the same session -> manually enter a wrong answer for the previous question and display a new one
4. page is reloaded, question time is exceeded, user session is the same and we have an answer -> nothing we can do...

For more details, see also #311 

Closes #311