### PR TITLE
Extract catmodel subplugin

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install moodle-plugin-ci
         run: |
           moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_wunderbyte_table
-          moodle-plugin-ci add-plugin --branch catmodel_subplugins_with_mod_form_reload Wunderbyte-GmbH/moodle-mod_adaptivequiz
+          moodle-plugin-ci add-plugin --branch catmodel_subplugins_with_mod_form_reload_400 Wunderbyte-GmbH/moodle-mod_adaptivequiz
           moodle-plugin-ci add-plugin --branch master branchup/moodle-filter_shortcodes
           moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-adaptivequizcatmodel_catquiz
 

--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -103,6 +103,7 @@ jobs:
           moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_wunderbyte_table
           moodle-plugin-ci add-plugin --branch catmodel_subplugins_with_mod_form_reload Wunderbyte-GmbH/moodle-mod_adaptivequiz
           moodle-plugin-ci add-plugin --branch master branchup/moodle-filter_shortcodes
+          moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-adaptivequizcatmodel_catquiz
 
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:


### PR DESCRIPTION
I updated our mirror of the adaptivequiz subplugin and removed the catquiz subplugin there.
This means, it has to be installed separately now.
This PR contains the changes to do this automatically when running Github actions.

Note: this includes branch `catmodel_subplugins_with_mod_form_reload_400 ` , which can work with Moodle 4.0.