### PR TITLE
bugfix no items found in scale error

### DIFF
--- a/classes/teststrategy/preselect_task/checkitemparams.php
+++ b/classes/teststrategy/preselect_task/checkitemparams.php
@@ -51,6 +51,7 @@ final class checkitemparams extends preselect_task implements wb_middleware {
      *
      */
     public function run(array &$context, callable $next): result {
+        $selectedscales = $context['selectedsubscales'];
         foreach ($context['selectedsubscales'] as $catscaleid) {
             $catscalecontext = catscale::get_context_id($catscaleid);
             $catscaleids = [
@@ -66,10 +67,16 @@ final class checkitemparams extends preselect_task implements wb_middleware {
                 ));
             }
             if (array_sum($itemparamlists) === 0) {
-                // TODO: Maybe unset this $catscaleid from list, when there are no items found.
-                return result::err(status::ERROR_NO_ITEMS);
+                $context['progress']->drop_scale($catscaleid);
+                unset($selectedscales[array_search($catscaleid, $selectedscales)]);
             }
         }
+
+        // If there are no active scales left, show a message that the quiz can not be started.
+        if (!$selectedscales) {
+                return result::err(status::ERROR_NO_ITEMS);
+        }
+
         return $next($context);
     }
 

--- a/classes/teststrategy/preselect_task/checkitemparams.php
+++ b/classes/teststrategy/preselect_task/checkitemparams.php
@@ -66,6 +66,7 @@ final class checkitemparams extends preselect_task implements wb_middleware {
                 ));
             }
             if (array_sum($itemparamlists) === 0) {
+                // TODO: Maybe unset this $catscaleid from list, when there are no items found.
                 return result::err(status::ERROR_NO_ITEMS);
             }
         }


### PR DESCRIPTION
I had an empty catscale in the db, so this error occured and no quiz could be played.
but other scales contained items. 
maybe should we adjust the handling for this case?