### PR TITLE
GH-329 Enforce max attempt time

### DIFF
--- a/classes/local/status.php
+++ b/classes/local/status.php
@@ -93,4 +93,11 @@ class status {
      * @var string
      */
     const ERROR_NO_ITEMS = 'errornoitems';
+
+    /**
+     * The maximum attempt time was exceeded.
+     *
+     * @var string
+     */
+    const EXCEEDED_MAX_ATTEMPT_TIME = 'exceededmaxattempttime';
 }

--- a/classes/teststrategy/progress.php
+++ b/classes/teststrategy/progress.php
@@ -166,6 +166,13 @@ class progress implements JsonSerializable {
     private array $gaveupquestions;
 
     /**
+     * Holds the starttime of the attempt.
+     *
+     * @var int
+     */
+    private int $starttime;
+
+    /**
      * Returns a new progress instance.
      *
      * If we already have data in the cache or DB, the instance is populated with those data.
@@ -293,6 +300,7 @@ class progress implements JsonSerializable {
         $instance->session = $data->session;
         $instance->excludedquestions = $data->excludedquestions;
         $instance->gaveupquestions = $data->gaveupquestions;
+        $instance->starttime = $data->starttime;
 
         return $instance;
     }
@@ -328,6 +336,7 @@ class progress implements JsonSerializable {
         $instance->session = sesskey();
         $instance->excludedquestions = [];
         $instance->gaveupquestions = [];
+        $instance->starttime = time();
         return $instance;
     }
 
@@ -353,6 +362,7 @@ class progress implements JsonSerializable {
             'session' => $this->session,
             'excludedquestions' => $this->excludedquestions,
             'gaveupquestions' => $this->gaveupquestions,
+            'starttime' => $this->starttime,
         ];
     }
 
@@ -906,6 +916,15 @@ class progress implements JsonSerializable {
      */
     public function get_ignore_last_response() {
         return $this->ignorelastresponse ?? false;
+    }
+
+    /**
+     * Returns the timestamp of the quiz start.
+     *
+     * @return int
+     */
+    public function get_starttime(): int {
+        return $this->starttime;
     }
 
     /**


### PR DESCRIPTION
If the maximum time for an attempt is exceeded, do not even start to execute the pre-select tasks but instead return immediately. While most other things are implemented as pre-select tasks, in this case it is easier to return early because we do not want to generate any feedback for a question that would be selected and would skip the remaining pre-select tasks anyway.