### PR TITLE
Dev david issue 318

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -949,6 +949,7 @@ class catquiz {
      * Returns the highest status for the given item in the given context
      * @param int $testitemid
      * @param int $contextid
+     * @param bool $withmodel If true, also the model name is returned
      * @return array
      */
     public static function get_sql_for_max_status_for_item(int $testitemid, int $contextid, bool $withmodel = false) {

--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -951,9 +951,9 @@ class catquiz {
      * @param int $contextid
      * @return array
      */
-    public static function get_sql_for_max_status_for_item(int $testitemid, int $contextid) {
+    public static function get_sql_for_max_status_for_item(int $testitemid, int $contextid, bool $withmodel = false) {
         $sql = "
-            SELECT max(status)
+            SELECT max(status) as status
             FROM {local_catquiz_itemparams}
             WHERE componentid = :itemid
               AND contextid = :contextid
@@ -963,6 +963,19 @@ class catquiz {
             'itemid' => $testitemid,
             'contextid' => $contextid,
         ];
+
+        if ($withmodel) {
+            $sql = "
+            SELECT ip.model, ip.status
+            FROM {local_catquiz_itemparams} ip
+            INNER JOIN ( $sql )
+            s1 ON ip.status = s1.status
+            WHERE ip.componentid = :itemid2
+                AND ip.contextid = :contextid2
+            ";
+            $params['itemid2'] = $testitemid;
+            $params['contextid2'] = $contextid;
+        }
 
         return [$sql, $params];
     }

--- a/classes/form/item_model_override_selector.php
+++ b/classes/form/item_model_override_selector.php
@@ -118,7 +118,7 @@ class item_model_override_selector extends dynamic_form {
             $mform->addGroup($group, $id, '');
             $mform->hideIf($id, sprintf('override_%s_select', $model), 'in', [
                 LOCAL_CATQUIZ_STATUS_NOT_CALCULATED,
-                LOCAL_CATQUIZ_STATUS_EXCLUDED_MANUALLY
+                LOCAL_CATQUIZ_STATUS_EXCLUDED_MANUALLY,
             ]);
             $mform->disabledIf($id, sprintf('override_%s_select', $model), 'eq', LOCAL_CATQUIZ_STATUS_CALCULATED);
         }

--- a/classes/form/item_model_override_selector.php
+++ b/classes/form/item_model_override_selector.php
@@ -22,6 +22,7 @@ global $CFG;
 require_once("$CFG->libdir/formslib.php");
 require_once($CFG->dirroot . "/local/catquiz/lib.php");
 
+use cache_helper;
 use context;
 use context_system;
 use core_form\dynamic_form;
@@ -320,6 +321,7 @@ class item_model_override_selector extends dynamic_form {
             ],
             ]);
             $event->trigger();
+            cache_helper::purge_by_event('changesintestitems');
         }
 
         foreach ($toinsert as $new) {

--- a/classes/form/item_model_override_selector.php
+++ b/classes/form/item_model_override_selector.php
@@ -27,8 +27,6 @@ use context_system;
 use core_form\dynamic_form;
 use local_catquiz\catquiz;
 use local_catquiz\event\testitemstatus_updated;
-use local_catquiz\local\model\model_item_param;
-use local_catquiz\local\model\model_item_param_list;
 use local_catquiz\local\model\model_strategy;
 use moodle_url;
 use stdClass;
@@ -468,17 +466,9 @@ class item_model_override_selector extends dynamic_form {
             }
 
             foreach ($values as $name => $value) {
-                if ($name === 'difficulty') {
-                    $dataarray[sprintf('%s_difficultylabel', $field)] = get_string('itemdifficulty', 'local_catquiz') . ":";
-                    $dataarray[sprintf('%s_difficulty', $field)] = $value;
-                    continue;
-                } else if ($name === 'guessing') {
-                    $dataarray[sprintf('%s_guessinglabel', $field)] = get_string('guessing', 'local_catquiz') . ":";
-                    $dataarray[sprintf('%s_guessing', $field)] = $value;
-                    continue;
-                } else if ($name === 'discrimination') {
-                    $dataarray[sprintf('%s_discriminationlabel', $field)] = get_string('discrimination', 'local_catquiz') . ":";
-                    $dataarray[sprintf('%s_discrimination', $field)] = $value;
+                if (in_array($name, ['difficulty', 'guessing', 'discrimination'])) {
+                    $dataarray[sprintf('%s_%slabel', $field, $name)] = get_string($name, 'local_catquiz') . ":";
+                    $dataarray[sprintf('%s_%s', $field, $name)] = $value;
                     continue;
                 }
             }

--- a/classes/output/testitemdashboard.php
+++ b/classes/output/testitemdashboard.php
@@ -218,27 +218,39 @@ class testitemdashboard implements renderable, templatable {
     /**
      * Gets item status.
      *
-     * @return string
+     * @return array
      * @throws coding_exception
      */
-    private function get_itemstatus() {
+    private function get_itemstatus(): array {
         global $DB;
-        list ($sql, $params) = catquiz::get_sql_for_max_status_for_item($this->testitemid, $this->contextid);
-        $maxstatus = intval($DB->get_field_sql($sql, $params));
+        list ($sql, $params) = catquiz::get_sql_for_max_status_for_item($this->testitemid, $this->contextid, true);
+        $result = $DB->get_record_sql($sql, $params);
+        $maxstatus = $result->status;
+        $modelname = get_string('pluginname', sprintf('catmodel_%s', $result->model));
         switch ($maxstatus) {
             case LOCAL_CATQUIZ_STATUS_EXCLUDED_MANUALLY:
-                return get_string('itemstatus_-5', 'local_catquiz');
+                $statusstring = get_string('itemstatus_-5', 'local_catquiz');
+                break;
             case LOCAL_CATQUIZ_STATUS_NOT_CALCULATED:
-                return get_string('itemstatus_0', 'local_catquiz');
+                $statusstring = get_string('itemstatus_0', 'local_catquiz');
+                break;
             case LOCAL_CATQUIZ_STATUS_CALCULATED:
-                return get_string('itemstatus_1', 'local_catquiz');
+                $statusstring = get_string('itemstatus_1', 'local_catquiz');
+                break;
             case LOCAL_CATQUIZ_STATUS_CONFIRMED_MANUALLY:
-                return get_string('itemstatus_5', 'local_catquiz');
+                $statusstring = get_string('itemstatus_5', 'local_catquiz');
+                break;
             case LOCAL_CATQUIZ_STATUS_UPDATED_MANUALLY:
-                return get_string('itemstatus_4', 'local_catquiz');
+                $statusstring = get_string('itemstatus_4', 'local_catquiz');
+                break;
             default:
-                return get_string('notavailable', 'core');
+                $statusstring = get_string('notavailable', 'core');
         }
+
+        return [
+            'model' => $modelname,
+            'status' => $statusstring,
+        ];
     }
     /**
      * Check if we display a table or a detailview of a specific item.

--- a/templates/tabs/tab_models.mustache
+++ b/templates/tabs/tab_models.mustache
@@ -46,8 +46,11 @@
       {{#str}} status, core {{/str}}
       <a href="javascript:void(0);" onclick="window.location.reload();"> <i class="fa fa-refresh float-right"></i> </a>
     </div>
-    <div class="card-body" style="display: flex; justify-content: center; align-items: center;">
-      <h3>{{itemstatus}}</h3>
+    <div class="card-body" style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
+    {{#itemstatus}}
+      <h3>{{status}}</h3>
+      <h4>{{model}}</h4>
+    {{/itemstatus}}
     </div>
   </div>
   {{#models}}


### PR DESCRIPTION
See #318 

This changes the item override form so that:
- no parameters are displayed if the status is set to "not yet calculated"
- textfields are disabled if the value is set to "calculated"

Also, the *Status* card on the same page now also shows the model that corresponds to the selected status.

