### PR TITLE
GH-425 Fix: save ability after each question

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -1524,7 +1524,7 @@ class catquiz {
         $data->total_number_of_testitems = $attemptdata['total_number_of_testitems'];
         $data->number_of_testitems_used = $attemptdata['number_of_testitems_used'];
         $data->personability_before_attempt = $attemptdata['ability_before_attempt'];
-        $data->personability_after_attempt = $attemptdata['personabilities'][$attemptdata['catscaleid']]['value'] ?? null;
+        $data->personability_after_attempt = $attemptdata['progress']->get_abilities()[$attemptdata['catscaleid']] ?? null;
         $data->starttime = $attemptdata['starttime'] ?? null;
         $data->endtime = $attemptdata['endtime'] ?? time();
 

--- a/classes/feedback/feedbackclass.php
+++ b/classes/feedback/feedbackclass.php
@@ -394,7 +394,11 @@ class feedbackclass {
                 $subelements[] = $mform->addElement(
                     'advcheckbox',
                     'enrolment_message_checkbox_' . $scale->id . '_'. $j,
-                    get_string('setautonitificationonenrolmentforscale', 'local_catquiz'), null, null, [0, 1]);
+                    get_string('setautonitificationonenrolmentforscale', 'local_catquiz'),
+                    null,
+                    null,
+                    [0, 1]
+                );
 
                 $enrolmentcheckbox = isset($defaultvalues['enrolment_message_checkbox_' . $scale->id . '_'. $j])
                     ? $defaultvalues['enrolment_message_checkbox_' . $scale->id . '_'. $j]


### PR DESCRIPTION
We tried to read the ability after from a non-existent array key and therefore always used null as fallback value. This is fixed here.