### PR TITLE
Use quiz settings from attempt start

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -1501,7 +1501,7 @@ class catquiz {
 
         // To query the db only once we fetch courseid und instanceid here.
         $courseandinstance = self::return_course_and_instance_id(
-            $attemptdata['quizsettings']['modulename'],
+            $attemptdata['quizsettings']->modulename,
             $attemptdata['attemptid']
         );
 
@@ -1511,7 +1511,7 @@ class catquiz {
         $data->contextid = $catcontext;
         $data->courseid = $courseandinstance['courseid'];
         $data->attemptid = $attemptdata['attemptid'];
-        $data->component = $attemptdata['quizsettings']['modulename'];
+        $data->component = $attemptdata['quizsettings']->modulename;
         $data->instanceid = $courseandinstance['instanceid'];
         $data->teststrategy = $attemptdata['teststrategy'];
         $data->status = LOCAL_CATQUIZ_ATTEMPT_OK;

--- a/classes/teststrategy/context/loader/personability_loader.php
+++ b/classes/teststrategy/context/loader/personability_loader.php
@@ -112,7 +112,7 @@ class personability_loader implements contextloaderinterface {
         if ($context['includesubscales']) {
             array_push(
                 $catscaleids,
-                ...$context['selectedsubscales']
+                ...$this->progress->get_selected_subscales()
             );
         }
         $personparams = catquiz::get_person_abilities(

--- a/classes/teststrategy/context/loader/progress_loader.php
+++ b/classes/teststrategy/context/loader/progress_loader.php
@@ -56,6 +56,7 @@ class progress_loader implements contextloaderinterface {
             'component',
             'contextid',
             'questionsattempted',
+            'quizsettings',
         ];
     }
 
@@ -66,7 +67,7 @@ class progress_loader implements contextloaderinterface {
      * @return array
      */
     public function load(array $context): array {
-        $progress = progress::load($context['attemptid'], $context['component'], $context['contextid']);
+        $progress = progress::load($context['attemptid'], $context['component'], $context['contextid'], $context['quizsettings']);
         if ($context['questionsattempted'] > 0) {
             $progress->update_cached_responses()
                 ->set_first_question_played();

--- a/classes/teststrategy/context/loader/questions_loader.php
+++ b/classes/teststrategy/context/loader/questions_loader.php
@@ -83,7 +83,7 @@ class questions_loader implements contextloaderinterface {
             $context['contextid'],
             $context['includesubscales'],
             'difficulty',
-            $context['selectedsubscales'],
+            $context['progress']->get_selected_subscales(),
         );
         $context['questions_ordered_by'] = 'difficulty';
         $context['original_questions'] = $context['questions'];

--- a/classes/teststrategy/feedbackgenerator.php
+++ b/classes/teststrategy/feedbackgenerator.php
@@ -39,8 +39,25 @@ use UnexpectedValueException;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class feedbackgenerator {
+    /**
+     * Attempt ID
+     *
+     * @var int
+     */
     private int $attemptid;
+
+    /**
+     * Component ID
+     *
+     * @var string
+     */
     private string $component = 'mod_adaptivequiz';
+
+    /**
+     * Context ID
+     *
+     * @var int
+     */
     private int $contextid;
 
     /**
@@ -161,7 +178,6 @@ abstract class feedbackgenerator {
      *
      * @param array $newdata
      * @param feedbacksettings $feedbacksettings
-     * @param array $quizsettings
      * @param int $strategyid
      * @param int $forcedscaleid
      * @param bool $feedbackonlyfordefinedscaleid

--- a/classes/teststrategy/feedbackgenerator.php
+++ b/classes/teststrategy/feedbackgenerator.php
@@ -75,7 +75,7 @@ abstract class feedbackgenerator {
      * @param array $data
      * @return array
      */
-    abstract public function get_studentfeedback(array $data): array;
+    abstract protected function get_studentfeedback(array $data): array;
 
     /**
      * Returns an array with two keys 'heading' and 'context'.

--- a/classes/teststrategy/feedbackgenerator.php
+++ b/classes/teststrategy/feedbackgenerator.php
@@ -61,12 +61,22 @@ abstract class feedbackgenerator {
     private int $contextid;
 
     /**
+     * @var ?progress
+     */
+    private ?progress $progress = null;
+
+    /**
      * Returns the progress for the current attempt, component and contextid.
      *
      * @return progress
      */
     protected function get_progress(): progress {
-        return progress::load($this->attemptid, $this->component, $this->contextid);
+        if ($this->progress) {
+            return $this->progress;
+        }
+
+        $this->progress = progress::load($this->attemptid, $this->component, $this->contextid);
+        return $this->progress;
     }
 
     /**

--- a/classes/teststrategy/feedbackgenerator.php
+++ b/classes/teststrategy/feedbackgenerator.php
@@ -107,6 +107,14 @@ abstract class feedbackgenerator {
      */
     abstract public function get_generatorname(): string;
 
+    /**
+     * Update the feedback data that is stored in the DB to render the feedback
+     *
+     * @param int $attemptid
+     * @param array $existingdata
+     * @param array $newdata
+     * @return null|array
+     */
     public function update_data(int $attemptid, array $existingdata, array $newdata): ?array {
         $this->attemptid = $attemptid;
         $this->contextid = $newdata['contextid'];

--- a/classes/teststrategy/feedbackgenerator.php
+++ b/classes/teststrategy/feedbackgenerator.php
@@ -39,6 +39,19 @@ use UnexpectedValueException;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class feedbackgenerator {
+    private int $attemptid;
+    private string $component = 'mod_adaptivequiz';
+    private int $contextid;
+
+    /**
+     * Returns the progress for the current attempt, component and contextid.
+     *
+     * @return progress
+     */
+    protected function get_progress(): progress {
+        return progress::load($this->attemptid, $this->component, $this->contextid);
+    }
+
     /**
      * Returns an array with two keys 'heading' and 'context'.
      *
@@ -77,6 +90,12 @@ abstract class feedbackgenerator {
      */
     abstract public function get_generatorname(): string;
 
+    public function update_data(int $attemptid, array $existingdata, array $newdata): ?array {
+        $this->attemptid = $attemptid;
+        $this->contextid = $newdata['contextid'];
+        return $this->load_data($attemptid, $existingdata, $newdata);
+    }
+
     /**
      * Loads the data required to render the feedback.
      *
@@ -106,6 +125,8 @@ abstract class feedbackgenerator {
      * @throws UnexpectedValueException
      */
     public function get_feedback(array $feedbackdata): array {
+        $this->attemptid = $feedbackdata['attemptid'];
+        $this->contextid = $feedbackdata['contextid'];
         // Check if all required data are provided. If not, load them.
         if (!$this->has_required_context_keys($feedbackdata)) {
             return $this->no_data();
@@ -151,11 +172,11 @@ abstract class feedbackgenerator {
     public function select_scales_for_report(
         array $newdata,
         feedbacksettings $feedbacksettings,
-        array $quizsettings,
         int $strategyid,
         int $forcedscaleid = 0,
         bool $feedbackonlyfordefinedscaleid = false
         ): array {
+            $quizsettings = $newdata['progress']->get_quiz_settings();
 
         $transformedpersonabilities = $newdata['updated_personabilities'];
 

--- a/classes/teststrategy/feedbackgenerator/comparetotestaverage.php
+++ b/classes/teststrategy/feedbackgenerator/comparetotestaverage.php
@@ -131,7 +131,6 @@ class comparetotestaverage extends feedbackgenerator {
         return [
             'contextid',
             'personabilities',
-            'quizsettings',
             'testaverageability',
             'userability',
             'testaverageposition',
@@ -139,7 +138,6 @@ class comparetotestaverage extends feedbackgenerator {
             'comparisontext',
             'colorbar',
             'colorbarlegend',
-            'quizsettings',
             'comparetotestaverage_has_worse',
             'comparetotestaverage_has_enough_peers',
         ];
@@ -271,8 +269,8 @@ class comparetotestaverage extends feedbackgenerator {
      *
      */
     public function load_data(int $attemptid, array $existingdata, array $newdata): ?array {
-        $progress = progress::load($attemptid, 'mod_adaptivequiz', $existingdata['contextid']);
-        $quizsettings = $existingdata['quizsettings'];
+        $progress = $this->get_progress();
+        $quizsettings = $progress->get_quiz_settings();
 
         if (!$progress->get_playedquestions()) {
             return [];
@@ -286,7 +284,6 @@ class comparetotestaverage extends feedbackgenerator {
         $personabilitiesfeedbackeditor = $this->select_scales_for_report(
             $newdata,
             $this->feedbacksettings,
-            $quizsettings,
             $existingdata['teststrategy']
         );
 

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -87,9 +87,10 @@ class customscalefeedback extends feedbackgenerator {
         if (!$data['customscalefeedback_abilities'] ?? false) {
             return [];
         }
+        $progress = $this->get_progress();
         $customscalefeedback = $this->get_customscalefeedback_for_abilities_in_range(
             $data['customscalefeedback_abilities'],
-            $data['quizsettings'],
+            (array) $progress->get_quiz_settings(),
             $data['catscales']
         );
         $firstelement = $data['customscalefeedback_abilities'][array_key_first($data['customscalefeedback_abilities'])];
@@ -143,8 +144,8 @@ class customscalefeedback extends feedbackgenerator {
      */
     public function get_required_context_keys(): array {
         return [
-            'quizsettings',
             'customscalefeedback_abilities',
+            'progress',
         ];
     }
 
@@ -179,8 +180,8 @@ class customscalefeedback extends feedbackgenerator {
      *
      */
     public function load_data(int $attemptid, array $existingdata, array $newdata): ?array {
-        $quizsettings = $existingdata['quizsettings'];
-        $progress = progress::load($attemptid, 'mod_adaptivequiz', $existingdata['contextid']);
+        $progress = $this->get_progress();
+        $quizsettings = $progress->get_quiz_settings();
         $personabilities = $progress->get_abilities();
 
         if (!$personabilities) {
@@ -190,12 +191,10 @@ class customscalefeedback extends feedbackgenerator {
         $personabilitiesfeedbackeditor = $this->select_scales_for_report(
             $newdata,
             $this->feedbacksettings,
-            $quizsettings,
             $existingdata['teststrategy']
         );
 
         return [
-            'quizsettings' => $quizsettings,
             'personabilities' => $personabilities,
             'customscalefeedback_abilities' => $personabilitiesfeedbackeditor,
         ];

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -145,7 +145,6 @@ class customscalefeedback extends feedbackgenerator {
     public function get_required_context_keys(): array {
         return [
             'customscalefeedback_abilities',
-            'progress',
         ];
     }
 

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -181,7 +181,6 @@ class customscalefeedback extends feedbackgenerator {
      */
     public function load_data(int $attemptid, array $existingdata, array $newdata): ?array {
         $progress = $this->get_progress();
-        $quizsettings = $progress->get_quiz_settings();
         $personabilities = $progress->get_abilities();
 
         if (!$personabilities) {

--- a/classes/teststrategy/feedbackgenerator/graphicalsummary.php
+++ b/classes/teststrategy/feedbackgenerator/graphicalsummary.php
@@ -179,7 +179,7 @@ class graphicalsummary extends feedbackgenerator {
      *
      */
     public function load_data(int $attemptid, array $existingdata, array $newdata): ?array {
-        $progress = progress::load($attemptid, 'mod_adaptivequiz', $existingdata['contextid']);
+        $progress = $this->get_progress();
 
         // If we already have all the data, just return them instead of adding
         // the last response again.
@@ -225,7 +225,7 @@ class graphicalsummary extends feedbackgenerator {
             info::get_teststrategy($existingdata['teststrategy'])
         ->get_description());
 
-        $progress = progress::load($attemptid, 'mod_adaptivequiz', $existingdata['contextid']);
+        $progress = $this->get_progress();
         return [
             'graphicalsummary_data' => $graphicalsummary,
             'teststrategyname' => $teststrategyname,
@@ -494,7 +494,7 @@ class graphicalsummary extends feedbackgenerator {
         global $OUTPUT;
         $series = [];
         $labels = [];
-        $quizsettings = $attemptdata['quizsettings'];
+        $quizsettings = $this->get_progress()->get_quiz_settings();
 
         foreach ($attemptsbytimerange as $timestamp => $attempts) {
             $labels[] = (string)$timestamp;

--- a/classes/teststrategy/feedbackgenerator/learningprogress.php
+++ b/classes/teststrategy/feedbackgenerator/learningprogress.php
@@ -155,7 +155,6 @@ class learningprogress extends feedbackgenerator {
      */
     public function get_required_context_keys(): array {
         return [
-            'progress',
             'primaryscale',
             'personabilities_abilities',
         ];
@@ -322,8 +321,7 @@ class learningprogress extends feedbackgenerator {
         // If defined in settings, display only feedbacks if items were played...
         // ...and parentscale and primaryscale.
         $questionpreviews = "";
-        if (isset($newdata['progress']->playedquestionsbyscale[$catscaleid])) {
-            $questionsinscale = $newdata['progress']->playedquestionsbyscale[$catscaleid];
+        if ($questionsinscale = $this->get_progress()->get_playedquestions(true, $catscaleid)) {
             $numberofitems = ['itemsplayed' => count($questionsinscale)];
             $questionpreviews = array_map(fn($q) => [
                 'preview' => $this->render_questionpreview((object) $q)['body']['question']],

--- a/classes/teststrategy/feedbackgenerator/learningprogress.php
+++ b/classes/teststrategy/feedbackgenerator/learningprogress.php
@@ -155,7 +155,7 @@ class learningprogress extends feedbackgenerator {
      */
     public function get_required_context_keys(): array {
         return [
-            'quizsettings',
+            'progress',
             'primaryscale',
             'personabilities_abilities',
         ];
@@ -210,20 +210,19 @@ class learningprogress extends feedbackgenerator {
         global $CFG;
         require_once($CFG->dirroot . '/local/catquiz/lib.php');
 
-        $progress = progress::load($existingdata['attemptid'], 'mod_adaptivequiz', $existingdata['contextid']);
+        $progress = $this->get_progress();
         $personabilities = $progress->get_abilities();
 
         if ($personabilities === []) {
             return null;
         }
-        $quizsettings = $existingdata['quizsettings'];
+        $quizsettings = $progress->get_quiz_settings();
         $catscales = $newdata['catscales'];
 
         // Make sure that only feedback defined by strategy is rendered.
         $personabilitiesfeedbackeditor = $this->select_scales_for_report(
             $newdata,
             $this->feedbacksettings,
-            $quizsettings,
             $existingdata['teststrategy']
         );
 
@@ -249,7 +248,6 @@ class learningprogress extends feedbackgenerator {
         }
 
         return [
-            'quizsettings' => (array) $quizsettings,
             'primaryscale' => $catscales[$selectedscaleid],
             'personabilities_abilities' => $personabilities,
         ];
@@ -428,7 +426,7 @@ class learningprogress extends feedbackgenerator {
                 }
             }
             $colorvalue = $this->get_color_for_personability(
-                (array)$initialcontext['quizsettings'],
+                (array) $this->get_progress()->get_quiz_settings(),
                 $as,
                 intval($primarycatscale['id'])
                 );

--- a/classes/teststrategy/feedbackgenerator/personabilities.php
+++ b/classes/teststrategy/feedbackgenerator/personabilities.php
@@ -155,7 +155,6 @@ class personabilities extends feedbackgenerator {
             'se',
             'abilitieslist',
             'models',
-            'progress',
         ];
     }
 
@@ -339,8 +338,7 @@ class personabilities extends feedbackgenerator {
         // If defined in settings, display only feedbacks if items were played...
         // ...and parentscale and primaryscale.
         $questionpreviews = "";
-        if (isset($newdata['progress']->playedquestionsbyscale[$catscaleid])) {
-            $questionsinscale = $newdata['progress']->playedquestionsbyscale[$catscaleid];
+        if ($questionsinscale = $this->get_progress()->get_playedquestions(true, $catscaleid)) {
             $numberofitems = ['itemsplayed' => count($questionsinscale)];
             $questionpreviews = array_map(fn($q) => [
                 'preview' => $this->render_questionpreview((object) $q)['body']['question']],
@@ -443,7 +441,7 @@ class personabilities extends feedbackgenerator {
                 }
             }
             $colorvalue = $this->get_color_for_personability(
-                (array)$initialcontext['progress']->get_quiz_settings(),
+                (array) $this->get_progress()->get_quiz_settings(),
                 $as,
                 intval($primarycatscale['id'])
                 );

--- a/classes/teststrategy/feedbackgenerator/personabilities.php
+++ b/classes/teststrategy/feedbackgenerator/personabilities.php
@@ -338,19 +338,6 @@ class personabilities extends feedbackgenerator {
         // If defined in settings, display only feedbacks if items were played...
         // ...and parentscale and primaryscale.
         $questionpreviews = "";
-        if ($questionsinscale = $this->get_progress()->get_playedquestions(true, $catscaleid)) {
-            $numberofitems = ['itemsplayed' => count($questionsinscale)];
-            $questionpreviews = array_map(fn($q) => [
-                'preview' => $this->render_questionpreview((object) $q)['body']['question']],
-                $questionsinscale
-            );
-        } else if ($this->feedbacksettings->displayscaleswithoutitemsplayed
-            || $catscaleid == $selectedscaleid
-            || $catscales[$catscaleid]->parentid == 0) {
-            $numberofitems = ['noplayed' => 0];
-        } else if ($catscaleid != $selectedscaleid) {
-            $numberofitems = "";
-        }
         if (isset($newdata['se'][$catscaleid])) {
             $standarderror = sprintf("%.2f", $newdata['se'][$catscaleid]);
         } else {
@@ -362,7 +349,7 @@ class personabilities extends feedbackgenerator {
             'ability' => $ability,
             'name' => $catscales[$catscaleid]->name,
             'catscaleid' => $catscaleid,
-            'numberofitemsplayed' => $numberofitems,
+            'numberofitemsplayed' => "",
             'questionpreviews' => $questionpreviews ?: "",
             'isselectedscale' => $isselectedscale,
             'tooltiptitle' => $tooltiptitle,

--- a/classes/teststrategy/feedbackgenerator/personabilities.php
+++ b/classes/teststrategy/feedbackgenerator/personabilities.php
@@ -108,7 +108,7 @@ class personabilities extends feedbackgenerator {
 
         $abilitieschart = $this->render_chart(
             $feedbackdata['personabilities_abilities'],
-            $feedbackdata['quizsettings'],
+            (array) $this->get_progress()->get_quiz_settings(),
             $feedbackdata['primaryscale'],
         );
 
@@ -150,12 +150,12 @@ class personabilities extends feedbackgenerator {
      */
     public function get_required_context_keys(): array {
         return [
-            'quizsettings',
             'primaryscale',
             'personabilities_abilities',
             'se',
             'abilitieslist',
             'models',
+            'progress',
         ];
     }
 
@@ -208,20 +208,19 @@ class personabilities extends feedbackgenerator {
         global $CFG;
         require_once($CFG->dirroot . '/local/catquiz/lib.php');
 
-        $progress = progress::load($existingdata['attemptid'], 'mod_adaptivequiz', $existingdata['contextid']);
+        $progress = $this->get_progress();
         $personabilities = $progress->get_abilities();
 
         if ($personabilities === []) {
             return null;
         }
-        $quizsettings = $existingdata['quizsettings'];
+        $quizsettings = $progress->get_quiz_settings();
         $catscales = $newdata['catscales'];
 
         // Make sure that only feedback defined by strategy is rendered.
         $personabilitiesfeedbackeditor = $this->select_scales_for_report(
             $newdata,
             $this->feedbacksettings,
-            $quizsettings,
             $existingdata['teststrategy']
         );
 
@@ -263,7 +262,6 @@ class personabilities extends feedbackgenerator {
         $models = model_strategy::get_installed_models();
 
         return [
-            'quizsettings' => (array) $quizsettings,
             'primaryscale' => $catscales[$selectedscaleid],
             'personabilities_abilities' => $personabilities,
             'se' => $newdata['se'] ?? null,
@@ -445,7 +443,7 @@ class personabilities extends feedbackgenerator {
                 }
             }
             $colorvalue = $this->get_color_for_personability(
-                (array)$initialcontext['quizsettings'],
+                (array)$initialcontext['progress']->get_quiz_settings(),
                 $as,
                 intval($primarycatscale['id'])
                 );

--- a/classes/teststrategy/feedbacksettings.php
+++ b/classes/teststrategy/feedbacksettings.php
@@ -16,7 +16,7 @@
 
 namespace local_catquiz\teststrategy;
 
-use \stdClass;
+use stdClass;
 use local_catquiz\catscale;
 use local_catquiz\feedback\feedbackclass;
 use local_catquiz\output\attemptfeedback;

--- a/classes/teststrategy/feedbacksettings.php
+++ b/classes/teststrategy/feedbacksettings.php
@@ -16,6 +16,7 @@
 
 namespace local_catquiz\teststrategy;
 
+use \stdClass;
 use local_catquiz\catscale;
 use local_catquiz\feedback\feedbackclass;
 use local_catquiz\output\attemptfeedback;
@@ -363,12 +364,11 @@ class feedbacksettings {
      * Filter the results to check if reporting is enabled in quizsettings.
      *
      * @param array $personabilities
-     * @param array $quizsettings
+     * @param stdClass $quizsettings
      *
      * @return array
-     *
      */
-    public function filter_excluded_scales(array $personabilities, \stdClass $quizsettings): array {
+    public function filter_excluded_scales(array $personabilities, stdClass $quizsettings): array {
         foreach ($personabilities as $catscale => $array) {
             $propertyname = sprintf('catquiz_scalereportcheckbox_%s', $catscale);
             if (empty($quizsettings->$propertyname)) {
@@ -386,12 +386,11 @@ class feedbacksettings {
      * Set params defined in quizsettings and attemptdata.
      *
      * @param array $newdata
-     * @param array $quizsettings
+     * @param stdClass $quizsettings
      *
      * @return void
-     *
      */
-    public function set_params_from_attempt(array $newdata, \stdClass $quizsettings): void {
+    public function set_params_from_attempt(array $newdata, stdClass $quizsettings): void {
         $this->semax = $newdata['se_max'] ?? null;
         $this->semin = $newdata['se_min'] ?? null;
         $maxquestiongroup = isset($quizsettings->maxquestionsgroup) ? (array) $quizsettings->maxquestionsgroup : null;

--- a/classes/teststrategy/preselect_task/checkitemparams.php
+++ b/classes/teststrategy/preselect_task/checkitemparams.php
@@ -51,8 +51,8 @@ final class checkitemparams extends preselect_task implements wb_middleware {
      *
      */
     public function run(array &$context, callable $next): result {
-        $selectedscales = $context['selectedsubscales'];
-        foreach ($context['selectedsubscales'] as $catscaleid) {
+        $selectedscales = [$context['catscaleid'], ...$context['progress']->get_selected_subscales()];
+        foreach ($selectedscales as $catscaleid) {
             $catscalecontext = catscale::get_context_id($catscaleid);
             $catscaleids = [
                 $catscaleid,
@@ -88,7 +88,7 @@ final class checkitemparams extends preselect_task implements wb_middleware {
      */
     public function get_required_context_keys(): array {
         return [
-            'selectedsubscales',
+            'progress',
         ];
     }
 }

--- a/classes/teststrategy/progress.php
+++ b/classes/teststrategy/progress.php
@@ -969,9 +969,7 @@ class progress implements JsonSerializable {
     /**
      * Gets selected subscales
      *
-     * @param stdClass $quizsettings
      * @return array
-     *
      */
     public function get_selected_subscales() {
         // Get selected subscales from quizdata.

--- a/tests/teststrategy/feedbackgenerator/customscalefeedback_test.php
+++ b/tests/teststrategy/feedbackgenerator/customscalefeedback_test.php
@@ -62,7 +62,7 @@ class customscalefeedback_test extends basic_testcase {
 
         $progressmock = $this->getMockBUilder(progress::class)
             ->onlyMethods([
-                'get_quiz_settings'
+                'get_quiz_settings',
             ])
             ->getMock();
         $progressmock

--- a/tests/teststrategy/feedbackgenerator/personabilities_test.php
+++ b/tests/teststrategy/feedbackgenerator/personabilities_test.php
@@ -28,6 +28,7 @@ namespace local_catquiz;
 use advanced_testcase;
 use local_catquiz\teststrategy\feedbackgenerator\personabilities;
 use local_catquiz\teststrategy\feedbacksettings;
+use local_catquiz\teststrategy\progress;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 
@@ -64,6 +65,16 @@ class personabilities_test extends advanced_testcase {
         array $testitemsforcatscale,
         array $fisherinfo) {
 
+        $progressmock = $this->getMockBUilder(progress::class)
+            ->onlyMethods([
+                'get_quiz_settings'
+            ])
+            ->getMock();
+
+        $progressmock
+            ->method('get_quiz_settings')
+            ->willReturn((object) $feedbackdata['quizsettings']);
+
         $feedbacksettings = new feedbacksettings(LOCAL_CATQUIZ_STRATEGY_LOWESTSUB);
         $personabilities = $this->getMockBuilder(personabilities::class)
             ->onlyMethods([
@@ -71,6 +82,7 @@ class personabilities_test extends advanced_testcase {
                 'get_testitems_for_catscale',
                 'get_fisherinfos_of_items',
                 'render_abilityprogress',
+                'get_progress',
             ])
             ->setConstructorArgs([$feedbacksettings])
             ->getMock();
@@ -91,8 +103,11 @@ class personabilities_test extends advanced_testcase {
                 'individual' => '',
                 'comparison' => '',
             ]);
+        $personabilities
+            ->method('get_progress')
+            ->willReturn($progressmock);
 
-        $output = $personabilities->get_studentfeedback($feedbackdata);
+        $output = $personabilities->get_feedback($feedbackdata)['studentfeedback'];
         // For the moment, this tests only the heading, not the whole rendered data.
         $this->assertEquals($expected['heading'], $output['heading']);
     }
@@ -108,6 +123,9 @@ class personabilities_test extends advanced_testcase {
         return [
             'lowestskillgap' => [
                 'feedbackdata' => [
+                    'attemptid' => 1,
+                    'se' => [],
+                    'progress' => [],
                     'userid' => '2',
                     'models' => [
                         "raschbirnbauma" => "catmodel_raschbirnbauma\raschbirnbauma",

--- a/tests/teststrategy/feedbackgenerator/personabilities_test.php
+++ b/tests/teststrategy/feedbackgenerator/personabilities_test.php
@@ -67,7 +67,7 @@ class personabilities_test extends advanced_testcase {
 
         $progressmock = $this->getMockBUilder(progress::class)
             ->onlyMethods([
-                'get_quiz_settings'
+                'get_quiz_settings',
             ])
             ->getMock();
 


### PR DESCRIPTION
If the settings of a quiz change, this does not affect attempts that are not yet finished - they continue to use the old settings from the attempt start.