### PR TITLE
GH-458 Update endtime and timemodified of attempts

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -1520,7 +1520,7 @@ class catquiz {
         $data->personability_before_attempt = $attemptdata['ability_before_attempt'];
         $data->personability_after_attempt = $attemptdata['progress']->get_abilities()[$attemptdata['catscaleid']] ?? null;
         $data->starttime = $attemptdata['starttime'] ?? null;
-        $data->endtime = $attemptdata['endtime'] ?? time();
+        $data->endtime = $attemptdata['endtime'] ?: time();
 
         $now = time();
         $data->timemodified = $now;

--- a/classes/catquiz_handler.php
+++ b/classes/catquiz_handler.php
@@ -858,11 +858,13 @@ class catquiz_handler {
         ): string {
         // Update the endtime and number of testitems used in the attempts table.
         global $DB, $COURSE;
+        $cache = cache::make('local_catquiz', 'adaptivequizattempt');
         $id = $DB->get_record('local_catquiz_attempts', ['attemptid' => $attemptrecord->id], 'id')->id;
         $data = (object) [
             'id' => $id,
             'number_of_testitems_used' => $attemptrecord->questionsattempted,
-            'endtime' => time(),
+            'endtime' => $cache->get('endtime'),
+            'timemodified' => time(),
         ];
         $DB->update_record('local_catquiz_attempts', $data);
 

--- a/classes/teststrategy/strategy.php
+++ b/classes/teststrategy/strategy.php
@@ -126,8 +126,13 @@ abstract class strategy {
      */
     public function return_next_testitem(array $context) {
         $cache = cache::make('local_catquiz', 'adaptivequizattempt');
-        if (time() - $context['progress']->get_starttime() > $context['max_attempttime_in_sec']) {
-            $cache->set('endtime', time());
+        $maxtime = $context['progress']->get_starttime() + $context['max_attempttime_in_sec'];
+        if (time() > $maxtime) {
+            // The 'endtime' holds the last timepoint that is relevant for the
+            // result. So if a student tries to answer a question after the
+            // time limit, this value is set to the time limit (starttime + max
+            // attempt time).
+            $cache->set('endtime', $maxtime);
             $cache->set('catquizerror', status::EXCEEDED_MAX_ATTEMPT_TIME);
             return result::err(status::EXCEEDED_MAX_ATTEMPT_TIME);
         }


### PR DESCRIPTION
The endtime is now set to the last point in time that was relevant for the result. The timemodified shows the time point of the last interaction, even if it was after the time limit.