### PR TITLE
Update course enrolment

### DIFF
--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -352,7 +352,7 @@ class attemptfeedback implements renderable, templatable {
         $groupstoenrol = $this->get_groups_to_enrol($feedbackdata, $quizsettings);
         $enrolementmsg = catquiz::enrol_user((array) $quizsettings, $coursestoenrol, $groupstoenrol);
         $courseandinstance = catquiz::return_course_and_instance_id(
-            $quizsettings['modulename'],
+            $quizsettings->modulename,
             $this->attemptid
         );
 
@@ -362,10 +362,10 @@ class attemptfeedback implements renderable, templatable {
             'context' => context_system::instance(),
             'other' => [
                 'attemptid' => $this->attemptid,
-                'catscaleid' => $quizsettings['catquiz_catscales'],
+                'catscaleid' => $quizsettings->catquiz_catscales,
                 'userid' => $USER->id,
                 'contextid' => $this->contextid,
-                'component' => $quizsettings['modulename'],
+                'component' => $quizsettings->modulename,
                 'instanceid' => $courseandinstance['instanceid'],
                 'teststrategy' => $this->teststrategy,
                 'status' => LOCAL_CATQUIZ_ATTEMPT_OK,
@@ -414,7 +414,7 @@ class attemptfeedback implements renderable, templatable {
         foreach ($candidatescales as $scaleid => $data) {
             $i = 0;
             $coursestoenrol[$scaleid] = [
-                'course_ids' => []
+                'course_ids' => [],
             ];
             while (isset($quizsettings['feedback_scaleid_limit_lower_' . $scaleid . '_'. ++$i])) {
                 $lowerlimit = $quizsettings['feedback_scaleid_limit_lower_' . $scaleid . '_'. $i];
@@ -448,12 +448,9 @@ class attemptfeedback implements renderable, templatable {
      *     '1' => [2,3]
      * ]
      *
-     * @param array $feedbackdata
-     * @param array $quizsettings
      * @return array
      */
-    public function get_groups_to_enrol(
-    ): array {
+    public function get_groups_to_enrol(): array {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 

--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -400,15 +400,11 @@ class attemptfeedback implements renderable, templatable {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 
-        $enrolonlytoreportedscales = $quizsettings['catquiz_enrol_only_reported_scales'] ?? true;
-        $candidatescales = $feedbackdata['personabilities_abilities'];
-        if ($enrolonlytoreportedscales) {
-            // Use only the toreport scale.
-            $candidatescales = array_filter(
-                $feedbackdata['personabilities_abilities'],
-                fn($v) => array_key_exists('toreport', $v) && $v['toreport'] === true
-            );
-        }
+        // Use only the toreport scale.
+        $candidatescales = array_filter(
+            $feedbackdata['personabilities_abilities'],
+            fn($v) => array_key_exists('toreport', $v) && $v['toreport'] === true
+        );
 
         $coursestoenrol = [];
         foreach ($candidatescales as $scaleid => $data) {
@@ -454,15 +450,11 @@ class attemptfeedback implements renderable, templatable {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 
-        $enrolonlytoreportedscales = $quizsettings['catquiz_enrol_only_reported_scales'] ?? true;
-        $candidatescales = $feedbackdata['personabilities_abilities'];
-        if ($enrolonlytoreportedscales) {
-            // Use only the toreport scale.
-            $candidatescales = array_filter(
-                $feedbackdata['personabilities_abilities'],
-                fn($v) => array_key_exists('toreport', $v) && $v['toreport'] === true
-            );
-        }
+        // Use only the toreport scale.
+        $candidatescales = array_filter(
+            $feedbackdata['personabilities_abilities'],
+            fn($v) => array_key_exists('toreport', $v) && $v['toreport'] === true
+        );
 
         // Check if there is a course associated with that value and if so, return it.
         $groupstoenrol = [];

--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -400,12 +400,9 @@ class attemptfeedback implements renderable, templatable {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 
-        // TODO: make sure that we can re-use the existing logic of inscribing
-        // to all scales and not only primary scales. Use a plugin setting for
-        // this.
-        $inscribetoallscales = true;
+        $enrolonlyprimaryscale = get_config('local_catquiz', 'enrol_only_to_primary_scale');
         $candidatescales = $feedbackdata['personabilities_abilities'];
-        if (!$inscribetoallscales) {
+        if ($enrolonlyprimaryscale) {
             // Use only the primary scale.
             $candidatescales = array_filter(
                 $feedbackdata['personabilities_abilities'],

--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -400,13 +400,13 @@ class attemptfeedback implements renderable, templatable {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 
-        $enrolonlyprimaryscale = get_config('local_catquiz', 'enrol_only_to_primary_scale');
+        $enrolonlytoreportedscales = $quizsettings['catquiz_enrol_only_reported_scales'] ?? true;
         $candidatescales = $feedbackdata['personabilities_abilities'];
-        if ($enrolonlyprimaryscale) {
-            // Use only the primary scale.
+        if ($enrolonlytoreportedscales) {
+            // Use only the toreport scale.
             $candidatescales = array_filter(
                 $feedbackdata['personabilities_abilities'],
-                fn($v) => array_key_exists('primary', $v) && $v['primary'] === true
+                fn($v) => array_key_exists('toreport', $v) && $v['toreport'] === true
             );
         }
 
@@ -454,13 +454,13 @@ class attemptfeedback implements renderable, templatable {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 
-        $enrolonlyprimaryscale = get_config('local_catquiz', 'enrol_only_to_primary_scale');
+        $enrolonlytoreportedscales = $quizsettings['catquiz_enrol_only_reported_scales'] ?? true;
         $candidatescales = $feedbackdata['personabilities_abilities'];
-        if ($enrolonlyprimaryscale) {
-            // Use only the primary scale.
+        if ($enrolonlytoreportedscales) {
+            // Use only the toreport scale.
             $candidatescales = array_filter(
                 $feedbackdata['personabilities_abilities'],
-                fn($v) => array_key_exists('primary', $v) && $v['primary'] === true
+                fn($v) => array_key_exists('toreport', $v) && $v['toreport'] === true
             );
         }
 

--- a/classes/output/attemptfeedback.php
+++ b/classes/output/attemptfeedback.php
@@ -412,10 +412,10 @@ class attemptfeedback implements renderable, templatable {
 
         $coursestoenrol = [];
         foreach ($candidatescales as $scaleid => $data) {
-            $i = 0;
             $coursestoenrol[$scaleid] = [
                 'course_ids' => [],
             ];
+            $i = 0;
             while (isset($quizsettings['feedback_scaleid_limit_lower_' . $scaleid . '_'. ++$i])) {
                 $lowerlimit = $quizsettings['feedback_scaleid_limit_lower_' . $scaleid . '_'. $i];
                 $upperlimit = $quizsettings['feedback_scaleid_limit_upper_' . $scaleid. '_'. $i];
@@ -454,12 +454,9 @@ class attemptfeedback implements renderable, templatable {
         $quizsettings = (array) $this->get_quiz_settings();
         $feedbackdata = $this->load_feedbackdata();
 
-        // TODO: make sure that we can re-use the existing logic of inscribing
-        // to all scales and not only primary scales. Use a plugin setting for
-        // this.
-        $inscribetoallscales = true;
+        $enrolonlyprimaryscale = get_config('local_catquiz', 'enrol_only_to_primary_scale');
         $candidatescales = $feedbackdata['personabilities_abilities'];
-        if (!$inscribetoallscales) {
+        if ($enrolonlyprimaryscale) {
             // Use only the primary scale.
             $candidatescales = array_filter(
                 $feedbackdata['personabilities_abilities'],
@@ -469,9 +466,9 @@ class attemptfeedback implements renderable, templatable {
 
         // Check if there is a course associated with that value and if so, return it.
         $groupstoenrol = [];
-        $i = 0;
         foreach ($candidatescales as $scaleid => $data) {
             $groupstoenrol[$scaleid] = [];
+            $i = 0;
             while (isset($quizsettings['feedback_scaleid_limit_lower_' . $scaleid . '_' . ++$i])) {
                 $lowerlimit = $quizsettings['feedback_scaleid_limit_lower_' . $scaleid . '_' . $i];
                 $upperlimit = $quizsettings['feedback_scaleid_limit_upper_' . $scaleid . '_' . $i];

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -108,9 +108,8 @@ $string['applychanges'] = 'Änderungen übernehmen';
 $string['automatic_reload_on_scale_selection'] = 'Bei (Sub-)Skalenauswahl Formular neu laden';
 $string['automatic_reload_on_scale_selection_description'] = 'Bei (Sub-)Skalenauswahl automatisch das Quizsettings-Formular neu laden';
 $string['enrol_only_to_reported_scales'] = 'Benutzer nur in Kurse von detektierter Skala einschreiben';
-$string['enrol_only_to_reported_scales_help'] = 'Falls es mehrere Kurse
-gibt, in die ein Benutzer laut Einstellungen und Ergebnis eingeschrieben werden
-kann, wird er nur in den Kurs mit der detektierten Skala eingeschrieben.'; // TODO: get translation.
+$string['enrol_only_to_reported_scales_help'] = 'Standardmäßig werden die Benutzer nach den Ergebnissen in den Bereichen eingeschrieben, die entsprechend dem Zweck des Tests ermittelt wurden.
+Wenn Sie diese Option deaktivieren, werden die Benutzer auch entsprechend aller anderen gültigen Ergebnissen eingeschrieben.'; // TODO: get translation.
 
 $string['timeoutabortnoresult'] = 'Test wird sofort beendet und nicht abschließend bewertet';
 $string['timeoutabortresult'] = 'Test wird sofort beendet und abschließend bewertet';

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -107,8 +107,8 @@ $string['peritem'] = 'pro Item ';
 $string['applychanges'] = 'Änderungen übernehmen';
 $string['automatic_reload_on_scale_selection'] = 'Bei (Sub-)Skalenauswahl Formular neu laden';
 $string['automatic_reload_on_scale_selection_description'] = 'Bei (Sub-)Skalenauswahl automatisch das Quizsettings-Formular neu laden';
-$string['enrol_only_to_primary_scale'] = 'Benutzer nur in Kurse von detektierter Skala einschreiben';
-$string['enrol_only_to_primary_scale_description'] = 'Falls es mehrere Kurse
+$string['enrol_only_to_reported_scales'] = 'Benutzer nur in Kurse von detektierter Skala einschreiben';
+$string['enrol_only_to_reported_scales_help'] = 'Falls es mehrere Kurse
 gibt, in die ein Benutzer laut Einstellungen und Ergebnis eingeschrieben werden
 kann, wird er nur in den Kurs mit der detektierten Skala eingeschrieben.'; // TODO: get translation.
 

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -107,6 +107,10 @@ $string['peritem'] = 'pro Item ';
 $string['applychanges'] = 'Änderungen übernehmen';
 $string['automatic_reload_on_scale_selection'] = 'Bei (Sub-)Skalenauswahl Formular neu laden';
 $string['automatic_reload_on_scale_selection_description'] = 'Bei (Sub-)Skalenauswahl automatisch das Quizsettings-Formular neu laden';
+$string['enrol_only_to_primary_scale'] = 'Benutzer nur in Kurse von detektierter Skala einschreiben';
+$string['enrol_only_to_primary_scale_description'] = 'Falls es mehrere Kurse
+gibt, in die ein Benutzer laut Einstellungen und Ergebnis eingeschrieben werden
+kann, wird er nur in den Kurs mit der detektierten Skala eingeschrieben.'; // TODO: get translation.
 
 $string['timeoutabortnoresult'] = 'Test wird sofort beendet und nicht abschließend bewertet';
 $string['timeoutabortresult'] = 'Test wird sofort beendet und abschließend bewertet';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -101,6 +101,10 @@ $string['peritem'] = 'per item ';
 $string['applychanges'] = 'Apply Changes';
 $string['automatic_reload_on_scale_selection'] = 'Form reload on scale selection';
 $string['automatic_reload_on_scale_selection_description'] = 'Reload quizsettings form automatically on (sub-)scale selection';
+$string['enrol_only_to_primary_scale'] = 'Enrol users only to courses of detected scales.';
+$string['enrol_only_to_primary_scale_description'] = 'If the user could be
+enroled to different courses according to the quiz settings, only enrol to the
+courses associated with the detected scale'; // TODO: get translation.
 
 $string['timeoutabortnoresult'] = 'Test aborted without result.';
 $string['timeoutabortresult'] = 'Test aborted with result.';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -101,10 +101,9 @@ $string['peritem'] = 'per item ';
 $string['applychanges'] = 'Apply Changes';
 $string['automatic_reload_on_scale_selection'] = 'Form reload on scale selection';
 $string['automatic_reload_on_scale_selection_description'] = 'Reload quizsettings form automatically on (sub-)scale selection';
-$string['enrol_only_to_reported_scales'] = 'Enrol users only to courses of detected scales.';
-$string['enrol_only_to_reported_scales_help'] = 'If the user could be
-enroled to different courses according to the quiz settings, only enrol to the
-courses associated with the detected scale'; // TODO: get translation.
+$string['enrol_only_to_reported_scales'] = 'Enrol users only to courses of detected primary scale(s).';
+$string['enrol_only_to_reported_scales_help'] = 'Standard would be to enrol users according to results in areas detected according to the purpose of the test.
+If you uncheck this option, users will be enroled according to all other valid results as well.'; // TODO: get translation.
 
 $string['timeoutabortnoresult'] = 'Test aborted without result.';
 $string['timeoutabortresult'] = 'Test aborted with result.';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -101,8 +101,8 @@ $string['peritem'] = 'per item ';
 $string['applychanges'] = 'Apply Changes';
 $string['automatic_reload_on_scale_selection'] = 'Form reload on scale selection';
 $string['automatic_reload_on_scale_selection_description'] = 'Reload quizsettings form automatically on (sub-)scale selection';
-$string['enrol_only_to_primary_scale'] = 'Enrol users only to courses of detected scales.';
-$string['enrol_only_to_primary_scale_description'] = 'If the user could be
+$string['enrol_only_to_reported_scales'] = 'Enrol users only to courses of detected scales.';
+$string['enrol_only_to_reported_scales_help'] = 'If the user could be
 enroled to different courses according to the quiz settings, only enrol to the
 courses associated with the detected scale'; // TODO: get translation.
 

--- a/settings.php
+++ b/settings.php
@@ -102,13 +102,4 @@ if ($hassiteconfig) {
             get_string('automatic_reload_on_scale_selection', 'local_catquiz'),
             get_string('automatic_reload_on_scale_selection_description', 'local_catquiz'),
             1));
-
-    $settings->add(
-        new admin_setting_configcheckbox(
-            'local_catquiz/enrol_only_to_primary_scale',
-            get_string('enrol_only_to_primary_scale', 'local_catquiz'),
-            get_string('enrol_only_to_primary_scale_description', 'local_catquiz'),
-            1,
-            true,
-            false));
 }

--- a/settings.php
+++ b/settings.php
@@ -102,4 +102,13 @@ if ($hassiteconfig) {
             get_string('automatic_reload_on_scale_selection', 'local_catquiz'),
             get_string('automatic_reload_on_scale_selection_description', 'local_catquiz'),
             1));
+
+    $settings->add(
+        new admin_setting_configcheckbox(
+            'local_catquiz/enrol_only_to_primary_scale',
+            get_string('enrol_only_to_primary_scale', 'local_catquiz'),
+            get_string('enrol_only_to_primary_scale_description', 'local_catquiz'),
+            1,
+            true,
+            false));
 }

--- a/tests/catquiz_test.php
+++ b/tests/catquiz_test.php
@@ -320,9 +320,15 @@ class catquiz_test extends advanced_testcase {
         $this->assertEmpty($this->get_user_enrolment($course));
         $this->assertEmpty(message_get_messages($USER->id, 0, -1, MESSAGE_GET_READ_AND_UNREAD));
 
+        $coursestoenrol = [];
+        $groupstoenrol = [];
+        if ($isenrolled) {
+            $coursestoenrol = [$catscaleid => ['show_message' => true, 'range' => 1, 'course_ids' => [$course->id]]];
+            $groupstoenrol = [$catscaleid => [$group->id]];
+        }
         // This is the function we want to test. After this call, the user should be added to the given group and enrolled to the
         // given course depending on the person ability of the user.
-        catquiz::enrol_user($USER->id, $quizsettings, $personabilities);
+        catquiz::enrol_user($quizsettings, $coursestoenrol, $groupstoenrol);
 
         // Check post-conditions.
         $groupmembers = groups_get_members($group->id);

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -47,7 +47,6 @@ class attemptfeedback_test extends advanced_testcase {
      * @param array $expected
      * @param array $feedbackdata
      * @param array $quizsettings
-     * @param bool $onlyprimary
      *
      * @return void
      * @throws InvalidArgumentException
@@ -57,11 +56,8 @@ class attemptfeedback_test extends advanced_testcase {
     public function test_it_returns_expected_courses_to_enrol(
         array $expected,
         array $feedbackdata,
-        array $quizsettings,
-        bool $onlyprimary = true
+        array $quizsettings
     ) {
-        $this->resetAfterTest(true);
-        set_config('enrol_only_to_primary_scale', $onlyprimary, 'local_catquiz');
         // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
         // The rest of the attemptfeedback class is unchanged.
         $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
@@ -109,7 +105,7 @@ class attemptfeedback_test extends advanced_testcase {
                         1 => [
                             'value' => 1.2,
                             'name' => 'Simulation',
-                            'primary' => true,
+                            'toreport' => true,
                         ],
                         2 => [
                             'value' => 1.2,
@@ -138,7 +134,7 @@ class attemptfeedback_test extends advanced_testcase {
                         1 => [
                             'value' => 6.0,
                             'name' => 'Simulation',
-                            'primary' => true,
+                            'toreport' => true,
                         ],
                     ],
                 ],
@@ -162,7 +158,7 @@ class attemptfeedback_test extends advanced_testcase {
                         1 => [
                             'value' => 1.2,
                             'name' => 'Simulation',
-                            'primary' => true,
+                            'toreport' => true,
                         ],
                         2 => [
                             'value' => 1.2,
@@ -176,9 +172,9 @@ class attemptfeedback_test extends advanced_testcase {
                         'feedback_scaleid_limit_lower_2_1' => 0,
                         'feedback_scaleid_limit_upper_2_1' => 5,
                         'catquiz_courses_2_1' => [3, 4],
+                        'catquiz_enrol_only_reported_scales' => "0",
                     ]
                 ),
-                'onlyprimary' => false,
             ],
         ];
     }
@@ -189,7 +185,6 @@ class attemptfeedback_test extends advanced_testcase {
      * @param array $expected
      * @param array $feedbackdata
      * @param array $quizsettings
-     * @param bool $onlyprimary
      *
      * @return void
      *
@@ -200,11 +195,8 @@ class attemptfeedback_test extends advanced_testcase {
     public function test_it_returns_expected_groups_to_enrol(
         array $expected,
         array $feedbackdata,
-        array $quizsettings,
-        bool $onlyprimary = true
+        array $quizsettings
     ) {
-        $this->resetAfterTest(true);
-        set_config('enrol_only_to_primary_scale', $onlyprimary, 'local_catquiz');
         // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
         // The rest of the attemptfeedback class is unchanged.
         $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
@@ -246,7 +238,7 @@ class attemptfeedback_test extends advanced_testcase {
                         1 => [
                             'value' => 1.2,
                             'name' => 'Simulation',
-                            'primary' => true,
+                            'toreport' => true,
                         ],
                     ],
                 ],
@@ -262,7 +254,7 @@ class attemptfeedback_test extends advanced_testcase {
                         1 => [
                             'value' => 6.0,
                             'name' => 'Simulation',
-                            'primary' => true,
+                            'toreport' => true,
                         ],
                     ],
                 ],
@@ -278,7 +270,7 @@ class attemptfeedback_test extends advanced_testcase {
                         1 => [
                             'value' => 1.2,
                             'name' => 'Simulation',
-                            'primary' => true,
+                            'toreport' => true,
                         ],
                         2 => [
                             'value' => 1.3,
@@ -292,9 +284,9 @@ class attemptfeedback_test extends advanced_testcase {
                         'feedback_scaleid_limit_lower_2_1' => 0,
                         'feedback_scaleid_limit_upper_2_1' => 5,
                         'catquiz_group_2_1' => "3,4,5",
+                        'catquiz_enrol_only_reported_scales' => "0",
                     ]
                 ),
-                'onlyprimary' => false,
             ],
         ];
     }

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -1,0 +1,199 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Test the attemptfeedback class
+ *
+ * @package    local_catquiz
+ * @author David Szkiba <david.szkiba@wunderbyte.at>
+ * @copyright  2023 Georg Maißer <info@wunderbyte.at>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_catquiz;
+
+use basic_testcase;
+use local_catquiz\output\attemptfeedback;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
+
+/**
+ * Tests the attemptfeedback class
+ *
+ * @package    local_catquiz
+ * @author David Szkiba <david.szkiba@wunderbyte.at>
+ * @copyright  2024 Wunderbyte GmbH
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \local_catquiz\output\attemptfeedback
+ */
+class attemptfeedback_test extends basic_testcase {
+    /**
+     * Checks if the attemptfeedback class returns the correct course enrolment data.
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     * @throws ExpectationFailedException
+     * @dataProvider strategy_returns_expected_courses_to_enrol_provider
+     */
+    public function test_it_returns_expected_courses_to_enrol($expected, $feedbackdata, $quizsettings) {
+        // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
+        // The rest of the attemptfeedback class is unchanged.
+        $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load_feedbackdata', 'get_quiz_settings'])
+            ->getMock();
+        $attemptfeedback
+            ->method('load_feedbackdata')
+            ->willReturn($feedbackdata);
+        $attemptfeedback
+            ->method('get_quiz_settings')
+            ->willReturn($quizsettings);
+
+        $result = $attemptfeedback->get_courses_to_enrol($feedbackdata, $quizsettings);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for test_strategy_returns_expected_courses_to_enrol
+     * @return array
+     */
+    public static function strategy_returns_expected_courses_to_enrol_provider(): array {
+        $scaleid = 1;
+        $quizsettings = [
+            sprintf('feedback_scaleid_limit_lower_%s_1', $scaleid) => -5,
+            sprintf('feedback_scaleid_limit_upper_%s_1', $scaleid) => 0,
+            sprintf('feedback_scaleid_limit_lower_%s_2', $scaleid) => 0,
+            sprintf('feedback_scaleid_limit_upper_%s_2', $scaleid) => 5,
+            sprintf('catquiz_courses_%s_1', $scaleid) => [1, 3],
+            sprintf('catquiz_courses_%s_2', $scaleid) => [2, 4],
+            sprintf('enrolment_message_checkbox_%s_1', $scaleid) => true,
+            sprintf('enrolment_message_checkbox_%s_2', $scaleid) => false,
+        ];
+        $feedbackdata = [
+            'personabilities_abilities' => [
+                1 => [
+                    'value' => 1.2,
+                    'name' => 'Simulation',
+                ],
+            ],
+        ];
+        return [
+            'Should enrol to two courses' => [
+                'expected' => [
+                    $scaleid => [
+                        'range' => 2,
+                        'show_message' => false,
+                        'course_ids' => [2, 4],
+                    ],
+                ],
+                'feedbackdata' => $feedbackdata,
+                'quizsettings' => $quizsettings,
+            ],
+            // The ability is outside the defined ranges.
+            'Should enrol to no course' => [
+                'expected' => [
+                    $scaleid => [
+                        'course_ids' => []
+                    ]
+                ],
+                [
+                    'personabilities_abilities' => [
+                        1 => [
+                            'value' => 6.0,
+                            'name' => 'Simulation',
+                        ]
+                    ],
+                ],
+                'quizsettings' => $quizsettings,
+            ]
+        ];
+    }
+
+    /**
+     * Checks if the the attemptfeedback class returns the correct group enrolment data.
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     * @throws ExpectationFailedException
+     * @dataProvider strategy_returns_expected_groups_to_enrol_provider
+     */
+    public function test_it_returns_expected_groups_to_enrol($expected, $feedbackdata, $quizsettings) {
+        // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
+        // The rest of the attemptfeedback class is unchanged.
+        $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['load_feedbackdata', 'get_quiz_settings'])
+            ->getMock();
+        $attemptfeedback
+            ->method('load_feedbackdata')
+            ->willReturn($feedbackdata);
+        $attemptfeedback
+            ->method('get_quiz_settings')
+            ->willReturn($quizsettings);
+
+        $result = $attemptfeedback->get_groups_to_enrol($feedbackdata, $quizsettings);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for test_strategy_returns_expected_courses_to_enrol
+     * @return array
+     */
+    public static function strategy_returns_expected_groups_to_enrol_provider(): array {
+        $scaleid = 1;
+        $quizsettings = [
+            sprintf('feedback_scaleid_limit_lower_%s_1', $scaleid) => -5,
+            sprintf('feedback_scaleid_limit_upper_%s_1', $scaleid) => 0,
+            sprintf('feedback_scaleid_limit_lower_%s_2', $scaleid) => 0,
+            sprintf('feedback_scaleid_limit_upper_%s_2', $scaleid) => 5,
+            sprintf('catquiz_group_%s_1', $scaleid) => "1,3",
+            sprintf('catquiz_group_%s_2', $scaleid) => "2,4",
+        ];
+        $feedbackdata = [
+            'personabilities_abilities' => [
+                1 => [
+                    'value' => 1.2,
+                    'name' => 'Simulation',
+                ],
+            ],
+        ];
+        return [
+            'Should enrol to two groups' => [
+                'expected' => [
+                    1 => [2, 4]
+                ],
+                'feedbackdata' => $feedbackdata,
+                'quizsettings' => $quizsettings,
+            ],
+            // The ability is outside the defined ranges.
+            'Should enrol to no group' => [
+                'expected' => [
+                    1 => [],
+                ],
+                [
+                    'personabilities_abilities' => [
+                        1 => [
+                            'value' => 6.0,
+                            'name' => 'Simulation',
+                        ]
+                    ],
+                ],
+                'quizsettings' => $quizsettings,
+            ]
+        ];
+    }
+}

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -67,7 +67,7 @@ class attemptfeedback_test extends basic_testcase {
             ->method('get_quiz_settings')
             ->willReturn($quizsettings);
 
-        $result = $attemptfeedback->get_courses_to_enrol($feedbackdata, $quizsettings);
+        $result = $attemptfeedback->get_courses_to_enrol();
         $this->assertEquals($expected, $result);
     }
 
@@ -154,7 +154,7 @@ class attemptfeedback_test extends basic_testcase {
             ->method('get_quiz_settings')
             ->willReturn($quizsettings);
 
-        $result = $attemptfeedback->get_groups_to_enrol($feedbackdata, $quizsettings);
+        $result = $attemptfeedback->get_groups_to_enrol();
         $this->assertEquals($expected, $result);
     }
 

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -25,7 +25,7 @@
 
 namespace local_catquiz;
 
-use basic_testcase;
+use advanced_testcase;
 use local_catquiz\output\attemptfeedback;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
@@ -40,20 +40,28 @@ use SebastianBergmann\RecursionContext\InvalidArgumentException;
  *
  * @covers \local_catquiz\output\attemptfeedback
  */
-class attemptfeedback_test extends basic_testcase {
+class attemptfeedback_test extends advanced_testcase {
     /**
      * Checks if the attemptfeedback class returns the correct course enrolment data.
      *
      * @param array $expected
      * @param array $feedbackdata
      * @param array $quizsettings
+     * @param bool $onlyprimary
      *
      * @return void
      * @throws InvalidArgumentException
      * @throws ExpectationFailedException
      * @dataProvider strategy_returns_expected_courses_to_enrol_provider
      */
-    public function test_it_returns_expected_courses_to_enrol(array $expected, array $feedbackdata, array $quizsettings) {
+    public function test_it_returns_expected_courses_to_enrol(
+        array $expected,
+        array $feedbackdata,
+        array $quizsettings,
+        bool $onlyprimary = true
+    ) {
+        $this->resetAfterTest(true);
+        set_config('enrol_only_to_primary_scale', $onlyprimary, 'local_catquiz');
         // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
         // The rest of the attemptfeedback class is unchanged.
         $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
@@ -87,16 +95,8 @@ class attemptfeedback_test extends basic_testcase {
             sprintf('enrolment_message_checkbox_%s_1', $scaleid) => true,
             sprintf('enrolment_message_checkbox_%s_2', $scaleid) => false,
         ];
-        $feedbackdata = [
-            'personabilities_abilities' => [
-                1 => [
-                    'value' => 1.2,
-                    'name' => 'Simulation',
-                ],
-            ],
-        ];
         return [
-            'Should enrol to two courses' => [
+            'Only primary: should enrol to two courses' => [
                 'expected' => [
                     $scaleid => [
                         'range' => 2,
@@ -104,11 +104,30 @@ class attemptfeedback_test extends basic_testcase {
                         'course_ids' => [2, 4],
                     ],
                 ],
-                'feedbackdata' => $feedbackdata,
-                'quizsettings' => $quizsettings,
+                'feedbackdata' => [
+                    'personabilities_abilities' => [
+                        1 => [
+                            'value' => 1.2,
+                            'name' => 'Simulation',
+                            'primary' => true,
+                        ],
+                        2 => [
+                            'value' => 1.2,
+                            'name' => 'Another scale with courses',
+                        ]
+                    ],
+                ],
+                'quizsettings' => array_merge(
+                    $quizsettings,
+                    [
+                        'feedback_scaleid_limit_lower_2_1' => 0,
+                        'feedback_scaleid_limit_upper_2_1' => 5,
+                        'catquiz_courses_2_1' => [3],
+                    ]
+                ),
             ],
             // The ability is outside the defined ranges.
-            'Should enrol to no course' => [
+            'Only primary: should enrol to no course' => [
                 'expected' => [
                     $scaleid => [
                         'course_ids' => [],
@@ -119,10 +138,47 @@ class attemptfeedback_test extends basic_testcase {
                         1 => [
                             'value' => 6.0,
                             'name' => 'Simulation',
+                            'primary' => true,
                         ],
                     ],
                 ],
                 'quizsettings' => $quizsettings,
+            ],
+            'All scales: should enrol to multiple courses from different scales' => [
+                'expected' => [
+                    $scaleid => [
+                        'range' => 2,
+                        'show_message' => false,
+                        'course_ids' => [2, 4],
+                    ],
+                    2 => [
+                        'range' => 1,
+                        'show_message' => false,
+                        'course_ids' => [3, 4],
+                    ]
+                ],
+                'feedbackdata' => [
+                    'personabilities_abilities' => [
+                        1 => [
+                            'value' => 1.2,
+                            'name' => 'Simulation',
+                            'primary' => true,
+                        ],
+                        2 => [
+                            'value' => 1.2,
+                            'name' => 'Another scale with courses',
+                        ]
+                    ],
+                ],
+                'quizsettings' => array_merge(
+                    $quizsettings,
+                    [
+                        'feedback_scaleid_limit_lower_2_1' => 0,
+                        'feedback_scaleid_limit_upper_2_1' => 5,
+                        'catquiz_courses_2_1' => [3, 4],
+                    ]
+                ),
+                'onlyprimary' => false,
             ],
         ];
     }
@@ -133,6 +189,7 @@ class attemptfeedback_test extends basic_testcase {
      * @param array $expected
      * @param array $feedbackdata
      * @param array $quizsettings
+     * @param bool $onlyprimary
      *
      * @return void
      *
@@ -140,7 +197,14 @@ class attemptfeedback_test extends basic_testcase {
      * @throws ExpectationFailedException
      * @dataProvider strategy_returns_expected_groups_to_enrol_provider
      */
-    public function test_it_returns_expected_groups_to_enrol(array $expected, array $feedbackdata, array $quizsettings) {
+    public function test_it_returns_expected_groups_to_enrol(
+        array $expected,
+        array $feedbackdata,
+        array $quizsettings,
+        bool $onlyprimary = true
+    ) {
+        $this->resetAfterTest(true);
+        set_config('enrol_only_to_primary_scale', $onlyprimary, 'local_catquiz');
         // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
         // The rest of the attemptfeedback class is unchanged.
         $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
@@ -172,24 +236,24 @@ class attemptfeedback_test extends basic_testcase {
             sprintf('catquiz_group_%s_1', $scaleid) => "1,3",
             sprintf('catquiz_group_%s_2', $scaleid) => "2,4",
         ];
-        $feedbackdata = [
-            'personabilities_abilities' => [
-                1 => [
-                    'value' => 1.2,
-                    'name' => 'Simulation',
-                ],
-            ],
-        ];
         return [
-            'Should enrol to two groups' => [
+            'Only primary: should enrol to two groups' => [
                 'expected' => [
                     1 => [2, 4],
                 ],
-                'feedbackdata' => $feedbackdata,
+                'feedbackdata' => [
+                    'personabilities_abilities' => [
+                        1 => [
+                            'value' => 1.2,
+                            'name' => 'Simulation',
+                            'primary' => true,
+                        ],
+                    ],
+                ],
                 'quizsettings' => $quizsettings,
             ],
             // The ability is outside the defined ranges.
-            'Should enrol to no group' => [
+            'Only primary: should enrol to no group' => [
                 'expected' => [
                     1 => [],
                 ],
@@ -198,10 +262,39 @@ class attemptfeedback_test extends basic_testcase {
                         1 => [
                             'value' => 6.0,
                             'name' => 'Simulation',
+                            'primary' => true,
                         ],
                     ],
                 ],
                 'quizsettings' => $quizsettings,
+            ],
+            'All scales: should enrol to multiple groups' => [
+                'expected' => [
+                    1 => [2, 4],
+                    2 => [3, 4, 5],
+                ],
+                'feedbackdata' => [
+                    'personabilities_abilities' => [
+                        1 => [
+                            'value' => 1.2,
+                            'name' => 'Simulation',
+                            'primary' => true,
+                        ],
+                        2 => [
+                            'value' => 1.3,
+                            'name' => 'Another scale',
+                        ],
+                    ],
+                ],
+                'quizsettings' => array_merge(
+                    $quizsettings,
+                    [
+                        'feedback_scaleid_limit_lower_2_1' => 0,
+                        'feedback_scaleid_limit_upper_2_1' => 5,
+                        'catquiz_group_2_1' => "3,4,5",
+                    ]
+                ),
+                'onlyprimary' => false,
             ],
         ];
     }

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -92,7 +92,7 @@ class attemptfeedback_test extends advanced_testcase {
             sprintf('enrolment_message_checkbox_%s_2', $scaleid) => false,
         ];
         return [
-            'Only primary: should enrol to two courses' => [
+            'Should enrol to two courses' => [
                 'expected' => [
                     $scaleid => [
                         'range' => 2,
@@ -123,7 +123,7 @@ class attemptfeedback_test extends advanced_testcase {
                 ),
             ],
             // The ability is outside the defined ranges.
-            'Only primary: should enrol to no course' => [
+            'Should enrol to no course' => [
                 'expected' => [
                     $scaleid => [
                         'course_ids' => [],
@@ -139,42 +139,6 @@ class attemptfeedback_test extends advanced_testcase {
                     ],
                 ],
                 'quizsettings' => $quizsettings,
-            ],
-            'All scales: should enrol to multiple courses from different scales' => [
-                'expected' => [
-                    $scaleid => [
-                        'range' => 2,
-                        'show_message' => false,
-                        'course_ids' => [2, 4],
-                    ],
-                    2 => [
-                        'range' => 1,
-                        'show_message' => false,
-                        'course_ids' => [3, 4],
-                    ],
-                ],
-                'feedbackdata' => [
-                    'personabilities_abilities' => [
-                        1 => [
-                            'value' => 1.2,
-                            'name' => 'Simulation',
-                            'toreport' => true,
-                        ],
-                        2 => [
-                            'value' => 1.2,
-                            'name' => 'Another scale with courses',
-                        ],
-                    ],
-                ],
-                'quizsettings' => array_merge(
-                    $quizsettings,
-                    [
-                        'feedback_scaleid_limit_lower_2_1' => 0,
-                        'feedback_scaleid_limit_upper_2_1' => 5,
-                        'catquiz_courses_2_1' => [3, 4],
-                        'catquiz_enrol_only_reported_scales' => "0",
-                    ]
-                ),
             ],
         ];
     }
@@ -229,7 +193,7 @@ class attemptfeedback_test extends advanced_testcase {
             sprintf('catquiz_group_%s_2', $scaleid) => "2,4",
         ];
         return [
-            'Only primary: should enrol to two groups' => [
+            'Should enrol to two groups' => [
                 'expected' => [
                     1 => [2, 4],
                 ],
@@ -245,7 +209,7 @@ class attemptfeedback_test extends advanced_testcase {
                 'quizsettings' => $quizsettings,
             ],
             // The ability is outside the defined ranges.
-            'Only primary: should enrol to no group' => [
+            'Should enrol to no group' => [
                 'expected' => [
                     1 => [],
                 ],
@@ -259,34 +223,6 @@ class attemptfeedback_test extends advanced_testcase {
                     ],
                 ],
                 'quizsettings' => $quizsettings,
-            ],
-            'All scales: should enrol to multiple groups' => [
-                'expected' => [
-                    1 => [2, 4],
-                    2 => [3, 4, 5],
-                ],
-                'feedbackdata' => [
-                    'personabilities_abilities' => [
-                        1 => [
-                            'value' => 1.2,
-                            'name' => 'Simulation',
-                            'toreport' => true,
-                        ],
-                        2 => [
-                            'value' => 1.3,
-                            'name' => 'Another scale',
-                        ],
-                    ],
-                ],
-                'quizsettings' => array_merge(
-                    $quizsettings,
-                    [
-                        'feedback_scaleid_limit_lower_2_1' => 0,
-                        'feedback_scaleid_limit_upper_2_1' => 5,
-                        'catquiz_group_2_1' => "3,4,5",
-                        'catquiz_enrol_only_reported_scales' => "0",
-                    ]
-                ),
             ],
         ];
     }

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -114,7 +114,7 @@ class attemptfeedback_test extends advanced_testcase {
                         2 => [
                             'value' => 1.2,
                             'name' => 'Another scale with courses',
-                        ]
+                        ],
                     ],
                 ],
                 'quizsettings' => array_merge(
@@ -155,7 +155,7 @@ class attemptfeedback_test extends advanced_testcase {
                         'range' => 1,
                         'show_message' => false,
                         'course_ids' => [3, 4],
-                    ]
+                    ],
                 ],
                 'feedbackdata' => [
                     'personabilities_abilities' => [
@@ -167,7 +167,7 @@ class attemptfeedback_test extends advanced_testcase {
                         2 => [
                             'value' => 1.2,
                             'name' => 'Another scale with courses',
-                        ]
+                        ],
                     ],
                 ],
                 'quizsettings' => array_merge(

--- a/tests/output/attemptfeedback_test.php
+++ b/tests/output/attemptfeedback_test.php
@@ -44,12 +44,16 @@ class attemptfeedback_test extends basic_testcase {
     /**
      * Checks if the attemptfeedback class returns the correct course enrolment data.
      *
+     * @param array $expected
+     * @param array $feedbackdata
+     * @param array $quizsettings
+     *
      * @return void
      * @throws InvalidArgumentException
      * @throws ExpectationFailedException
      * @dataProvider strategy_returns_expected_courses_to_enrol_provider
      */
-    public function test_it_returns_expected_courses_to_enrol($expected, $feedbackdata, $quizsettings) {
+    public function test_it_returns_expected_courses_to_enrol(array $expected, array $feedbackdata, array $quizsettings) {
         // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
         // The rest of the attemptfeedback class is unchanged.
         $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
@@ -107,31 +111,36 @@ class attemptfeedback_test extends basic_testcase {
             'Should enrol to no course' => [
                 'expected' => [
                     $scaleid => [
-                        'course_ids' => []
-                    ]
+                        'course_ids' => [],
+                    ],
                 ],
                 [
                     'personabilities_abilities' => [
                         1 => [
                             'value' => 6.0,
                             'name' => 'Simulation',
-                        ]
+                        ],
                     ],
                 ],
                 'quizsettings' => $quizsettings,
-            ]
+            ],
         ];
     }
 
     /**
      * Checks if the the attemptfeedback class returns the correct group enrolment data.
      *
+     * @param array $expected
+     * @param array $feedbackdata
+     * @param array $quizsettings
+     *
      * @return void
+     *
      * @throws InvalidArgumentException
      * @throws ExpectationFailedException
      * @dataProvider strategy_returns_expected_groups_to_enrol_provider
      */
-    public function test_it_returns_expected_groups_to_enrol($expected, $feedbackdata, $quizsettings) {
+    public function test_it_returns_expected_groups_to_enrol(array $expected, array $feedbackdata, array $quizsettings) {
         // We use a mock object so that we can work with the quiz settings and feedbackdata that we get from the data provider.
         // The rest of the attemptfeedback class is unchanged.
         $attemptfeedback = $this->getMockBuilder(attemptfeedback::class)
@@ -174,7 +183,7 @@ class attemptfeedback_test extends basic_testcase {
         return [
             'Should enrol to two groups' => [
                 'expected' => [
-                    1 => [2, 4]
+                    1 => [2, 4],
                 ],
                 'feedbackdata' => $feedbackdata,
                 'quizsettings' => $quizsettings,
@@ -189,11 +198,11 @@ class attemptfeedback_test extends basic_testcase {
                         1 => [
                             'value' => 6.0,
                             'name' => 'Simulation',
-                        ]
+                        ],
                     ],
                 ],
                 'quizsettings' => $quizsettings,
-            ]
+            ],
         ];
     }
 }

--- a/tests/teststrategy/strategy_test.php
+++ b/tests/teststrategy/strategy_test.php
@@ -30,11 +30,14 @@ use context_course;
 use context_module;
 use core_question\local\bank\question_edit_contexts;
 use local_catquiz\importer\testitemimporter;
+use local_catquiz\teststrategy\strategy;
 use mod_adaptivequiz\local\attempt\attempt;
 use mod_adaptivequiz\local\question\question_answer_evaluation;
+use PHPUnit\Framework\ExpectationFailedException;
 use question_bank;
 use question_engine;
 use question_usage_by_activity;
+use SebastianBergmann\RecursionContext\InvalidArgumentException;
 
 defined('MOODLE_INTERNAL') || die();
 global $CFG;

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_catquiz';
 $plugin->release = '0.9.4-rc8';
-$plugin->version = 2024050200;
+$plugin->version = 2024050700;
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_ALPHA;
 $plugin->dependencies = [


### PR DESCRIPTION
Closes #479 

- By default, enrol user only to courses and groups defined for the primary scale.
- Add a plugin setting to get the old behaviour: enrol into courses and groups of _all_ matching scales.

Refactorings:
since we already have the information about which scale is primary in the attempt data, we re-use them
1. There is a new method `get_courses_to_enrol` in attemptfeedback.php
2. There is a new method `get_groups_to_enrol` in attemptfeedback.php

These methods are only responsible for detecting the courses and groups.
Enrolment and sending of messages is still handled in the `catquiz` class as before.

I added `attemptfeedback_test` to check the course/group enrolment works as expected.