### PR TITLE
GH-537 Do not overwrite fisherinfo

### DIFF
--- a/classes/teststrategy/feedbackgenerator/debuginfo.php
+++ b/classes/teststrategy/feedbackgenerator/debuginfo.php
@@ -248,7 +248,7 @@ class debuginfo extends feedbackgenerator {
         $catscales = catquiz::get_catscales(array_keys($newdata['person_ability']));
         $teststrategy = get_string($reflect->getShortName(), 'local_catquiz');
 
-            $personabilities = [];
+        $personabilities = [];
         foreach ($newdata['person_ability'] as $catscaleid => $pp) {
             if (empty($catscales[$catscaleid])) {
                 continue;
@@ -259,12 +259,6 @@ class debuginfo extends feedbackgenerator {
 
             $questions = [];
             $questionsperscale = [];
-
-        if ($newdata['lastquestion']) {
-            $newdata['lastquestion']
-                ->fisherinformation = $newdata['lastquestion']->fisherinformation[$newdata['catscaleid']]
-            ?? 'NA';
-        }
 
             $activescales = array_map(
                 fn ($scaleid) => $catscales[$scaleid]->name,


### PR DESCRIPTION
Somehow [1], in the debuginfo feedback generator, the fisherinformation is overwritten. When this happens and the cache is deleted, the progress class will read the fisherinformation from the database where it gets the overwritten value. That value might now be a string like "NA" which causes errors.

1: the fisherinformation is overwritten because it is part of the `lastquestion` object in the `$newdata` array. Objects are passed by reference, and therefore changing the value in the feedback generator also changes it in outer scopes.