### PR TITLE
GH-566 Fix: always display reference scale

### DIFF
--- a/classes/teststrategy/feedbackgenerator/personabilities.php
+++ b/classes/teststrategy/feedbackgenerator/personabilities.php
@@ -123,6 +123,16 @@ class personabilities extends feedbackgenerator {
             'local_catquiz',
             feedback_helper::add_quotes($globalscalename)
         );
+        $referencescale = [
+            'name' => $globalscalename,
+            'ability' => feedback_helper::localize_float(
+                $this->get_progress()->get_abilities()[$feedbackdata['catscaleid']]
+            ),
+            'standarderror' => feedback_helper::localize_float(
+                $feedbackdata['se'][$feedbackdata['catscaleid']]
+            ),
+            'itemsplayed' => $this->get_progress()->get_num_playedquestions(),
+        ];
 
         $feedback = $OUTPUT->render_from_template(
         'local_catquiz/feedback/personabilities',
@@ -130,6 +140,7 @@ class personabilities extends feedbackgenerator {
             'feedback_details_description' => $description,
             'scale_info' => $scaleinfo,
             'abilities' => $feedbackdata['abilitieslist'],
+            'referencescale' => $referencescale,
             'chartdisplay' => $abilitieschart,
             'chart_description' => $chartdescription,
             ]

--- a/templates/feedback/personabilities.mustache
+++ b/templates/feedback/personabilities.mustache
@@ -80,16 +80,14 @@
         {{/is_global}}
         {{/abilities}}
         <tr><td>{{#str}} detected_scales_reference, local_catquiz {{/str}}:</td><td></td><td></td><td></td></tr>
-        {{#abilities}}
-        {{#is_global}}
+        {{#referencescale}}
         <tr>
             <td></td>
             <td>{{name}}</td>
             <td>{{ability}} (±{{standarderror}})</td>
-            <td>{{#numberofitemsplayed}}{{itemsplayed}}{{/numberofitemsplayed}}</td>
+            <td>{{itemsplayed}}</td>
         </tr>
-        {{/is_global}}
-        {{/abilities}}
+        {{/referencescale}}
     </tbody>
 </table>
 <p>{{{chart_description}}}</p>

--- a/templates/feedback/personabilities.mustache
+++ b/templates/feedback/personabilities.mustache
@@ -79,8 +79,8 @@
         </tr>
         {{/is_global}}
         {{/abilities}}
-        <tr><td>{{#str}} detected_scales_reference, local_catquiz {{/str}}:</td><td></td><td></td><td></td></tr>
         {{#referencescale}}
+        <tr><td>{{#str}} detected_scales_reference, local_catquiz {{/str}}:</td><td></td><td></td><td></td></tr>
         <tr>
             <td></td>
             <td>{{name}}</td>

--- a/tests/teststrategy/feedbackgenerator/personabilities_test.php
+++ b/tests/teststrategy/feedbackgenerator/personabilities_test.php
@@ -70,6 +70,7 @@ class personabilities_test extends advanced_testcase {
             ->onlyMethods([
                 'get_quiz_settings',
                 'get_abilities',
+                'get_num_playedquestions',
             ])
             ->getMock();
 
@@ -82,6 +83,9 @@ class personabilities_test extends advanced_testcase {
         $progressmock
             ->method('get_abilities')
             ->willReturn([$primaryscaleid => $primaryscalevalue]);
+        $progressmock
+            ->method('get_num_playedquestions')
+            ->willReturn(1);
 
         $feedbackhelpermock = $this->getMockBUilder(feedback_helper::class)
             ->disableOriginalConstructor()
@@ -132,7 +136,7 @@ class personabilities_test extends advanced_testcase {
                 'feedbackdata' => [
                     'catscaleid' => 271,
                     'attemptid' => 1,
-                    'se' => [],
+                    'se' => [271 => 0.12345],
                     'progress' => [],
                     'userid' => '2',
                     'models' => [


### PR DESCRIPTION
Even if reporting is disabled for the main scale, it should still be shown as reference in the personabilities feedback.