### PR TITLE
GH-575 Fix feedback text for results in low quantiles

### DIFF
--- a/classes/teststrategy/feedbackgenerator/comparetotestaverage.php
+++ b/classes/teststrategy/feedbackgenerator/comparetotestaverage.php
@@ -63,6 +63,16 @@ class comparetotestaverage extends feedbackgenerator {
     const MIN_USERS = 3;
 
     /**
+     * Limit to show comparison text
+     *
+     * We only show the comparison text "you are better than XX percent of
+     * users" if XX is greater than this value.
+     *
+     * @var int
+     */
+    const MIN_BETTER_THAN_LIMIT = 15;
+
+    /**
      * Get student feedback.
      *
      * @param array $data
@@ -271,12 +281,16 @@ class comparetotestaverage extends feedbackgenerator {
         $b = $middle - (float) $abilityrange['minscalevalue'];
         $testaverageposition = ($b + $testaverageinrange) / $b * 50;
         $userabilityposition = ($b + $abilityinrange) / $b * 50;
+        $betterthan = '';
+        if (round($quantile, 0) >= self::MIN_BETTER_THAN_LIMIT) {
+            $betterthan = get_string('feedbackcomparison_betterthan', 'local_catquiz', ['quantile' => round($quantile, 0)]);
+        }
 
         $text = get_string(
             'feedbackcomparetoaverage',
             'local_catquiz',
             [
-                'quantile' => round($quantile, 0),
+                'betterthan' => $betterthan,
                 'quotedscale' => feedback_helper::add_quotes($catscale->name),
                 'ability_global' => feedback_helper::localize_float($abilityinrange),
                 'se_global' => feedback_helper::localize_float($newdata['se'][$catscaleid]),

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -489,14 +489,14 @@ $string['attemptfeedbacknotyetavailable'] = "Feedback wird angezeigt, sobald es 
 $string['allquestionsincorrect'] = "Genauer Fähigkeits-Score kann nicht ermittelt werden, da alle Fragen falsch beantwortet wurden.";
 $string['allquestionscorrect'] = "Genauer Fähigkeits-Score kann nicht ermittelt werden, da alle Fragen richtig beantwortet wurden.";
 $string['minquestionsnotreached'] = 'Es konnte kein Testergebnis ermittelt werden, da die Mindestanzahl an zu beantortenden Fragen nicht erreicht wurde.';
-$string['feedbackcomparetoaverage'] = 'Der Test misst Ihr Wissen und Können in {$a->quotedscale} in Form eines Fähigkeitswertes zwischen
+$string['feedbackcomparetoaverage'] = '<p>Der Test misst Ihr Wissen und Können in {$a->quotedscale} in Form eines Fähigkeitswertes zwischen
 {$a->scale_min} und {$a->scale_max}. Je höher Ihr Fähigkeitswert ausfällt, desto besser ist Ihr Wissen und Ihr
-Können in der Skala.
-Ihr erreichter Fähigkeitswert ist {$a->ability_global} (mit einem Standardfehler von ± {$a->se_global}). Der aktuelle
-durchschnittliche Fähigkeitswert aller Teilnehmenden an dem Test beträgt {$a->average_ability}. Mit
-Ihrem Ergebnis sind Sie momentan besser als {$a->quantile}% aller anderen Test-Teilnehmenden.
-Die folgende Graﬁk stellt Ihren Fähigkeitswert (obere Markierung) und den aktuellen
-Durchschnitt (untere Markierung) dar:';
+Können in der Skala.</p>
+<p>Ihr erreichter Fähigkeitswert ist {$a->ability_global} (mit einem Standardfehler von ± {$a->se_global}). Der aktuelle
+durchschnittliche Fähigkeitswert aller Teilnehmenden an dem Test beträgt {$a->average_ability}. {$a->betterthan}</p>
+<p>Die folgende Graﬁk stellt Ihren Fähigkeitswert (obere Markierung) und den aktuellen
+Durchschnitt (untere Markierung) dar:</p>';
+$string['feedbackcomparison_betterthan'] = 'Mit Ihrem Ergebnis sind Sie momentan besser als {$a->quantile}% aller anderen Test-Teilnehmenden.';
 $string['questionssummary'] = "Zusammenfassung";
 $string['currentability'] = 'Ihr Fähigkeitswert';
 $string['currentabilityfellowstudents'] = 'Durchschnitt';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -472,10 +472,11 @@ $string['error'] = "An error occured";
 $string['id'] = "ID";
 $string['abortpersonabilitynotchanged'] = "Person parameter did not change";
 $string['emptyfirstquestionlist'] = "Can't select a start question because the list is empty";
-$string['feedbackcomparetoaverage'] = 'The test measures your ability in {$a->quotedscale} by calculating an ability score in the range between
-{$a->scale_min} and {$a->scale_max}. A higher value indicates a better ability.
-You reached a score of {$a->ability_global} (with a standard error of ± {$a->se_global}). The average score of all participants is {$a->average_ability}. Your score is better than {$a->quantile}% of all other participants.
-The following chart displays your personal score (upper mark) and the current average score (lower mark):';
+$string['feedbackcomparetoaverage'] = '<p>The test measures your ability in {$a->quotedscale} by calculating an ability score in the range between
+{$a->scale_min} and {$a->scale_max}. A higher value indicates a better ability.</p>
+<p>You reached a score of {$a->ability_global} (with a standard error of ± {$a->se_global}). The average score of all participants is {$a->average_ability}. {$a->betterthan}</p>
+<p>The following chart displays your personal score (upper mark) and the current average score (lower mark):</p>';
+$string['feedbackcomparison_betterthan'] = 'Your score is better than {$a->quantile}% of all other participants.';
 $string['errornoitems'] = "The quiz can not be started with the given settings. Please contact your CAT manager.";
 $string['exceededmaxattempttime'] = "The maximum attempt time has been exceeded.";
 

--- a/templates/feedback/comparetotestaverage.mustache
+++ b/templates/feedback/comparetotestaverage.mustache
@@ -44,9 +44,7 @@
        "subfeedbackrange": "3.3-0"
     }
 }}
-{{#comparetotestaverage_has_worse}}
-    {{{comparisontext}}}
-{{/comparetotestaverage_has_worse}}
+{{{comparisontext}}}
 {{#colorbar}}
     <div class="catquiz-feedbackbar">
         <div class="catquiz-feedbackbar-bar" style="background: linear-gradient(to right, {{colorgradestring}});">


### PR DESCRIPTION
Instead of hiding the whole feedback text, just do not display the feedback "you are better than XX% other participants" if XX is less than 15.