### PR TITLE
584 fix bad looping in catscale.php

### DIFF
--- a/classes/output/catscales.php
+++ b/classes/output/catscales.php
@@ -96,6 +96,7 @@ class catscales implements renderable, templatable {
             // Transform object catscale_structur into array, which is needed here.
             $element = get_object_vars($catscaleitem);
 
+            // Walk only elements on the current node, meaning with the given parentid
             if ($element['parentid'] !== $parentid) { continue; }
 
             if ($subscribed = subscription::return_subscription_state($USER->id, 'catscale', $element['id'])) {

--- a/classes/output/catscales.php
+++ b/classes/output/catscales.php
@@ -105,16 +105,15 @@ class catscales implements renderable, templatable {
                 $element['subscribed'] = false;
             }
 
-            if ($element['parentid'] == $parentid) {
-                $children = $this->build_tree($elements, $element['id']);
-                if ($children) {
-                    $element['children'] = $children;
-                } else {
-                    // Add empty array. That is needed for mustache templated in order to avoid infinit loop.
-                    $element['children'] = [];
-                }
-                $branch[] = $element;
+            $children = $this->build_tree($elements, $element['id']);
+            if ($children) {
+                $element['children'] = $children;
+            } else {
+                // Add empty array. That is needed for mustache templated in order to avoid infinit loop.
+                $element['children'] = [];
             }
+            $branch[] = $element;
+
         }
         $this->branchitems[$parentid] = $branch;
         return $branch;

--- a/classes/output/catscales.php
+++ b/classes/output/catscales.php
@@ -96,6 +96,8 @@ class catscales implements renderable, templatable {
             // Transform object catscale_structur into array, which is needed here.
             $element = get_object_vars($catscaleitem);
 
+            if ($element['parentid'] !== $parentid) { continue; }
+
             if ($subscribed = subscription::return_subscription_state($USER->id, 'catscale', $element['id'])) {
                 $element['subscribed'] = true;
             } else {


### PR DESCRIPTION
O(n^2+) => O(n)
Es wurden auf dem LTI-Server bei ca. 350 CAT-Skalen ca. 12000-mal die Subscription-Tabelle abgefragt, insgesamt wurden 120 MB (!) an Anfragen an die DB gestellt!

vorher:
<img width="454" alt="grafik" src="https://github.com/user-attachments/assets/0b126b38-be4c-4bad-9631-0219506d08ff">


nachher:
<img width="1358" alt="grafik" src="https://github.com/user-attachments/assets/df190479-578a-4604-865b-aca8a54c0f85">
