### PR TITLE
Ralferlebach fix capabilities problem on csv export

### DIFF
--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1122,6 +1122,7 @@ class catquizstatistics {
         }
 
         $params = [
+            'cid' => $this->courseid,
             'scaleid' => $this->scaleid,
             'courseid' => $this->courseid,
             'testid' => $this->testid,

--- a/export_shortcode_csv.php
+++ b/export_shortcode_csv.php
@@ -43,11 +43,10 @@ $PAGE->set_context(context_course::instance($cid));
 
 if (!has_capability('local/catquiz:view_users_feedback', context_course::instance($cid)) &&
     !has_capability('local/catquiz:canmanage', context_system::instance())) {
-    throw new \Exception(get_string($classname, 'local_catquiz','local/catquiz:view_users_feedback'));
+
+    throw new \Exception(get_string('error:permissionforcsvdownload', 'local_catquiz','local/catquiz:view_users_feedback'), 404);
     break;
 }
-
-
 
 require_once($CFG->dirroot . '/local/catquiz/lib.php');
 require_once($CFG->libdir . '/csvlib.class.php');

--- a/export_shortcode_csv.php
+++ b/export_shortcode_csv.php
@@ -28,18 +28,30 @@
 use local_catquiz\output\catquizstatistics;
 
 require_once('../../config.php');
-$context = \context_system::instance();
-$PAGE->set_context($context);
-require_login();
-require_capability('local/catquiz:canmanage', $context);
-require_once($CFG->dirroot . '/local/catquiz/lib.php');
-require_once($CFG->libdir . '/csvlib.class.php');
 
 $scaleid = required_param('scaleid', PARAM_INT);
+$cid = required_param('cid', PARAM_INT);
+
 $courseid = optional_param('courseid', 0, PARAM_INT) ?: null;
 $testid = optional_param('testid', 0, PARAM_INT) ?: null;
 $starttime = optional_param('starttime', 0, PARAM_INT) ?: null;
 $endtime = optional_param('endtime', 0, PARAM_INT) ?: null;
+
+require_login();
+
+$PAGE->set_context(context_course::instance($cid));
+
+if (!has_capability('local/catquiz:view_users_feedback', context_course::instance($cid)) &&
+    !has_capability('local/catquiz:canmanage', context_system::instance())) {
+    throw new \Exception(get_string($classname, 'local_catquiz','local/catquiz:view_users_feedback'));
+    break;
+}
+
+
+
+require_once($CFG->dirroot . '/local/catquiz/lib.php');
+require_once($CFG->libdir . '/csvlib.class.php');
+
 $catquizstatistics = new catquizstatistics($courseid, $testid, $scaleid, $endtime, $starttime);
 
 $filename = "shortcode_export_scale_$scaleid";

--- a/export_shortcode_csv.php
+++ b/export_shortcode_csv.php
@@ -44,8 +44,8 @@ $PAGE->set_context(context_course::instance($cid));
 if (!has_capability('local/catquiz:view_users_feedback', context_course::instance($cid)) &&
     !has_capability('local/catquiz:canmanage', context_system::instance())) {
 
-    throw new \Exception(get_string('error:permissionforcsvdownload', 'local_catquiz','local/catquiz:view_users_feedback'), 404);
-    break;
+    // throw new \Exception(get_string('error:permissionforcsvdownload', 'local_catquiz','local/catquiz:view_users_feedback'), 404);
+    die(get_string('error:permissionforcsvdownload', 'local_catquiz','local/catquiz:view_users_feedback'));
 }
 
 require_once($CFG->dirroot . '/local/catquiz/lib.php');

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -245,6 +245,7 @@ $string['enrolementstringstartforfeedback'] = 'Auf Grundlage Ihres Ergebnisses s
 $string['enrolled_courses'] = 'Eingeschriebene Kurse';
 $string['enrolmentmessagetitle'] = 'Benachrichtigung über neue Kurseinschreibung(en) / Gruppenmitgliedschaft(en)';
 $string['error'] = 'Es ist ein Fehler aufgetreten';
+$string['error:missingcapabilityforcsvdownload'] = 'Ihnen fehlt die notwendige Berechtigung, die Informationen herunterzuladen: {$a}.';
 $string['error:fraction0'] = 'Leider konnten wir aufgrund Ihrer Antworten kein zuverlässiges Ergebnis ermitteln.
     Wir würden uns freuen, wenn Sie es erneut versuchen.';
 $string['error:fraction1'] = 'Herzlichen Glückwunsch, Sie haben alle Fragen richtig beantwortet! Das ist wirklich großartig!

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -245,7 +245,7 @@ $string['enrolementstringstartforfeedback'] = 'Auf Grundlage Ihres Ergebnisses s
 $string['enrolled_courses'] = 'Eingeschriebene Kurse';
 $string['enrolmentmessagetitle'] = 'Benachrichtigung über neue Kurseinschreibung(en) / Gruppenmitgliedschaft(en)';
 $string['error'] = 'Es ist ein Fehler aufgetreten';
-$string['error:missingcapabilityforcsvdownload'] = 'Ihnen fehlt die notwendige Berechtigung, die Informationen herunterzuladen: {$a}.';
+$string['error:permissionforcsvdownload'] = 'Ihnen fehlt die notwendige Berechtigung ({$a}), die gewünschte Informationen herunterzuladen.';
 $string['error:fraction0'] = 'Leider konnten wir aufgrund Ihrer Antworten kein zuverlässiges Ergebnis ermitteln.
     Wir würden uns freuen, wenn Sie es erneut versuchen.';
 $string['error:fraction1'] = 'Herzlichen Glückwunsch, Sie haben alle Fragen richtig beantwortet! Das ist wirklich großartig!

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -241,6 +241,7 @@ $string['enrolementstringstartforfeedback'] = 'Based on your results you are now
 $string['enrolled_courses'] = 'Enrolled courses';
 $string['enrolmentmessagetitle'] = 'Notification about new course / group enrolments';
 $string['error'] = 'An error occured';
+$string['error:permissionforcsvdownload'] = 'You do not have the necessary permission ({$a}) to download the requested information.';
 $string['error:fraction0'] = 'Unfortunately, we were unable to determine a valid result based on your answers. We would be pleased if you would try again.';
 $string['error:fraction1'] = 'Congratulations, you have answered all the questions correctly! That is really awesome!
     However, due to this excellent performance, we were unable to determine a conclusive result.';


### PR DESCRIPTION
fixes #643 

@davidszkiba:
Kannst du in der export_shortcode_csv.php noch eine verständliche Error-Page einbauen, die statt der required_capability geworfen wird (anstelle des Fehlers jetzt)?