### PR TITLE
Dev david issue 643

### DIFF
--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1151,7 +1151,7 @@ class catquizstatistics {
 
         if (!has_capability('local/catquiz:canmanage', context_system::instance()) &&
             !has_capability('local/catquiz:view_users_feedback', context_course::instance($this->courseid))) {
-            return '';
+            return [];
         }
 
         list ($sql, $params) = catquiz::get_sql_for_csv_export(

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1175,9 +1175,9 @@ class catquizstatistics {
 
             $primaryscale = $additionalresults->primaryscale;
             $r->primaryid = $globalscale;
-            $r->primaryname = $additionalresults->catscales->$primaryscale->name;
-            $r->primarypp = $additionalresults->personabilities->$primaryscale;
-            $r->primaryse = $additionalresults->se->$primaryscale;
+            $r->primaryname = $additionalresults->catscales->{$primaryscale->id}->name;
+            $r->primarypp = $additionalresults->personabilities->{$primaryscale->id};
+            $r->primaryse = $additionalresults->se->{$primaryscale->id};
             // phpcs:disable
             /*
             $r->primaryn = $additionalresults->n->$primaryscale;

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1134,7 +1134,11 @@ class catquizstatistics {
             'endtime' => $this->endtime,
         ];
         $url = (new moodle_url('/local/catquiz/export_shortcode_csv.php', $params))->out(false);
-        return sprintf('<a class="btn btn-info" style="margin: 1em 0" id="download-link" href="%s">%s</a>', $url, get_string('download', 'admin'));
+        return sprintf(
+            '<a class="btn btn-info" style="margin: 1em 0" id="download-link" href="%s">%s</a>',
+            $url,
+            get_string('download', 'admin')
+        );
     }
 
     /**

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1117,8 +1117,12 @@ class catquizstatistics {
             'local/catquiz:view_users_feedback',
             context_course::instance($this->courseid)
         );
+
         if (!$hasglobalaccess && !$haslocalaccess) {
-            return '';
+            return sprintf(
+                '<div class="alert alert-primary mt-1" role="alert">%s</div>',
+                get_string('error:permissionforcsvdownload', 'local_catquiz', 'local/catquiz:view_users_feedback')
+            );
         }
 
         $params = [
@@ -1129,7 +1133,8 @@ class catquizstatistics {
             'starttime' => $this->starttime,
             'endtime' => $this->endtime,
         ];
-        return (new moodle_url('/local/catquiz/export_shortcode_csv.php', $params))->out(false);
+        $url = (new moodle_url('/local/catquiz/export_shortcode_csv.php', $params))->out(false);
+        return sprintf('<a class="btn btn-info" style="margin: 1em 0" id="download-link" href="%s">%s</a>', $url, get_string('download', 'admin'));
     }
 
     /**

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1183,7 +1183,7 @@ class catquizstatistics {
             */
             // phpcs:enable
 
-            $primaryscale = $additionalresults->primaryscale;
+            $primaryscale = $additionalresults->primaryscale->id;
             $r->primaryid = $primaryscale ?? '';
             $r->primaryname = $primaryscale ? $additionalresults->catscales->$primaryscale->name : '';
             $r->primarypp = $additionalresults->personabilities->$primaryscale ?? '';

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1170,13 +1170,13 @@ class catquizstatistics {
             // TODO: To be implemented: 'Ergebnis-Range', 'N global', 'frac global', 'N Ergebnisskala', 'frac Ergebnisskala'.
             $additionalresults = json_decode($r->json);
 
-            $r->testid = $additionalresults->testid;
+            $r->testid = $additionalresults->testid ?? '';
 
             $globalscale = $additionalresults->catscaleid;
-            $r->globalid = $globalscale;
-            $r->globalname = $additionalresults->catscales->$globalscale->name;
-            $r->globalpp = $additionalresults->personabilities->$globalscale;
-            $r->globalse = $additionalresults->se->$globalscale;
+            $r->globalid = $globalscale ?? '';
+            $r->globalname = $globalscale ? $additionalresults->catscales->$globalscale->name : '';
+            $r->globalpp = $additionalresults->personabilities->$globalscale ?? '';
+            $r->globalse = $additionalresults->se->$globalscale ?? '';
             /*
             $r->globaln = $additionalresults->n->$globalscale;
             $r->globalf = $additionalresults->frac->$globalscale;
@@ -1184,10 +1184,11 @@ class catquizstatistics {
             // phpcs:enable
 
             $primaryscale = $additionalresults->primaryscale;
-            $r->primaryid = $globalscale;
-            $r->primaryname = $additionalresults->catscales->$primaryscale->name;
-            $r->primarypp = $additionalresults->personabilities->$primaryscale;
-            $r->primaryse = $additionalresults->se->$primaryscale;
+            $r->primaryid = $primaryscale ?? '';
+            $r->primaryname = $primaryscale ? $additionalresults->catscales->$primaryscale->name : '';
+            $r->primarypp = $additionalresults->personabilities->$primaryscale ?? '';
+            $r->primaryse = $additionalresults->se->$primaryscale ?? '';
+
             // phpcs:disable
             /*
             $r->primaryn = $additionalresults->n->$primaryscale;

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1184,9 +1184,9 @@ class catquizstatistics {
 
             $primaryscale = $additionalresults->primaryscale;
             $r->primaryid = $globalscale;
-            $r->primaryname = $additionalresults->catscales->{$primaryscale->id}->name;
-            $r->primarypp = $additionalresults->personabilities->{$primaryscale->id};
-            $r->primaryse = $additionalresults->se->{$primaryscale->id};
+            $r->primaryname = $additionalresults->catscales->$primaryscale->name;
+            $r->primarypp = $additionalresults->personabilities->$primaryscale;
+            $r->primaryse = $additionalresults->se->$primaryscale;
             // phpcs:disable
             /*
             $r->primaryn = $additionalresults->n->$primaryscale;

--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -1149,8 +1149,9 @@ class catquizstatistics {
     public function get_export_data(): array {
         global $DB;
 
-        if (!has_capability('local/catquiz:canmanage', context_system::instance())) {
-            return [];
+        if (!has_capability('local/catquiz:canmanage', context_system::instance()) &&
+            !has_capability('local/catquiz:view_users_feedback', context_course::instance($this->courseid))) {
+            return '';
         }
 
         list ($sql, $params) = catquiz::get_sql_for_csv_export(

--- a/templates/catscaleshortcodes/catscalestatistics.mustache
+++ b/templates/catscaleshortcodes/catscalestatistics.mustache
@@ -107,7 +107,7 @@
             <h5 style="margin-top: 1em; margin-bottom: 0;">{{#str}}catquizstatistics_exportcsv_heading, local_catquiz{{/str}}</h5>
             <div>{{#str}}catquizstatistics_exportcsv_description, local_catquiz{{/str}}</div>
             <div style="display: flex; align-items: center; flex-direction: column;" class="flex-wrapper">
-                <a class="btn btn-info" style="margin: 1em 0" id="download-link" href="{{exportbutton}}">{{#str}}download, admin{{/str}}</a>
+                {{{ exportbutton }}}
             </div>
           </div>
         </div>

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_catquiz';
 $plugin->release = '1.0.3';
-$plugin->version = 2024082800;
+$plugin->version = 2024082900;
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
Fixes #643 

Zeigt eine Meldung an, wenn die Berechtigung zum Download eines Quiz Attempts als CSV fehlt:

![image](https://github.com/user-attachments/assets/ed243d02-23f8-4f3d-aefa-7a9c8873c3ba)

Die checks in `export_shortcode_csv.php` sind weiterhin vorhanden, falls jemand direkt über die URL auf den Export zugreift.