### PR TITLE
Dev david issue 663

### DIFF
--- a/classes/catscale.php
+++ b/classes/catscale.php
@@ -687,7 +687,7 @@ class catscale {
         $sql = "SELECT lcip.*
                 FROM {local_catquiz_items} lci
                 JOIN {local_catquiz_itemparams} lcip
-                ON (lci.componentid = lcip.itemid)
+                ON (lci.id = lcip.itemid AND lci.contextid = lcip.contextid)
                 WHERE lci.catscaleid $inorequal
                 AND lcip.contextid=:contextid";
         $params['catscaleid'] = $scaleid;


### PR DESCRIPTION
With the new DB structure, where each item points to its active item parameter via the `activeparamid` field, we have to duplicate items during import whenever itemparams are duplicated.

Closes #663 