### PR TITLE
GH-639 Fix saving of feedback images

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -1341,7 +1341,7 @@ class catquiz {
                 SQL_PARAMS_NAMED,
                 'incatscales'
             );
-            $where .= "AND catscaleid " . $inscalesql;
+            $where .= " AND catscaleid " . $inscalesql;
             $params = array_merge($params, $inscaleparams);
         }
 

--- a/classes/catquiz_handler.php
+++ b/classes/catquiz_handler.php
@@ -769,14 +769,7 @@ class catquiz_handler {
                     continue;
                 }
                 for ($j = 1; $j <= $nfeedbackoptions; $j++) {
-                    if ($feedbackvaluekey === 'feedbackeditor_scaleid_') {
-                        $keyname = $feedbackvaluekey . $scaleidofcopyvalue . '_' . $j . '_editor';
-                        if (!array_key_exists($keyname, $values)) {
-                            $keyname = $feedbackvaluekey . $scaleidofcopyvalue . '_' . $j;
-                        }
-                    } else {
-                        $keyname = $feedbackvaluekey . $scaleidofcopyvalue . '_' . $j;
-                    }
+                    $keyname = $feedbackvaluekey . $scaleidofcopyvalue . '_' . $j;
                     $standardvalues[$feedbackvaluekey][$j] = $values[$keyname] ?? null;
                 }
             }
@@ -801,9 +794,6 @@ class catquiz_handler {
                     }
                     for ($j = 1; $j <= $nfeedbackoptions; $j++) {
                         $subscalekey = $feedbackvaluekey . $subscaleid . '_' . $j;
-                        if ($feedbackvaluekey === 'feedbackeditor_scaleid_') {
-                            $subscalekey = sprintf('feedbackeditor_scaleid_%d_%d_editor', $subscaleid, $j);
-                        }
                         $values[$subscalekey] = $standardvalues[$feedbackvaluekey][$j];
                     }
                 }

--- a/classes/feedback/feedbackclass.php
+++ b/classes/feedback/feedbackclass.php
@@ -103,7 +103,8 @@ class feedbackclass {
         $mform->addHelpButton('numberoffeedbackoptionsselect', 'numberoffeedbackoptionpersubscale', 'local_catquiz');
         $elements[] = $element;
 
-        if (array_key_exists('instance', $data) && !$data['instance']) {
+        $instance = $data['instance'] ?? $defaultvalues['instance'] ?? "";
+        if (!$instance) {
             $picturewarning = get_string('picturesavewarning', 'local_catquiz');
             $element = $mform->createElement(
                 'html',

--- a/classes/feedback/feedbackclass.php
+++ b/classes/feedback/feedbackclass.php
@@ -272,7 +272,6 @@ class feedbackclass {
                 $subelements[] = $element;
 
                 // Rich text field for subfeedback.
-                //$subelements[] = $mform->addElement(
                 $element = $mform->addElement(
                     'editor',
                     'feedbackeditor_scaleid_' . $scale->id . '_' . $j,

--- a/classes/feedback/feedbackclass.php
+++ b/classes/feedback/feedbackclass.php
@@ -105,10 +105,12 @@ class feedbackclass {
 
         if (array_key_exists('instance', $data) && !$data['instance']) {
             $picturewarning = get_string('picturesavewarning', 'local_catquiz');
-            $element = $mform->addElement(
+            $element = $mform->createElement(
                 'html',
                 '<div class="alert alert-warning" role="alert">'.$picturewarning.'</div>'
             );
+            $element->setName('picturesavewarning');
+            $mform->addElement($element);
             $elements[] = $element;
         }
 

--- a/classes/testenvironment.php
+++ b/classes/testenvironment.php
@@ -269,7 +269,6 @@ class testenvironment {
             'noclean' => true,
         ];
 
-
         foreach ($jsonobject as $key => $value) {
 
             // Never overwrite a few values.
@@ -314,7 +313,6 @@ class testenvironment {
                 $filearea = sprintf('feedback_files_%d_%d', $scaleid, $rangeid);
                 $jsonobject[$key.'format'] = 1;
                 $field = sprintf('feedbackeditor_scaleid_%d_%d', $scaleid, $rangeid);
-                // Returns an object. 
                 $data = (object) file_prepare_standard_editor(
                     (object) $jsonobject,
                     $field,

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -24,6 +24,7 @@
 
 namespace local_catquiz\teststrategy\feedbackgenerator;
 
+use context_module;
 use local_catquiz\teststrategy\feedback_helper;
 use local_catquiz\teststrategy\feedbackgenerator;
 use local_catquiz\teststrategy\feedbacksettings;
@@ -312,7 +313,8 @@ class customscalefeedback extends feedbackgenerator {
      * @return ?string
      */
     private function getfeedbackforrange(int $catscaleid, int $groupnumber, array $quizsettings): ?string {
-        $systemcontext = \context_system::instance();
+        $cm = get_coursemodule_from_instance('adaptivequiz', $this->testid);
+        $context = context_module::instance($cm->id);
         $quizsettingskey = 'feedbackeditor_scaleid_' . $catscaleid . '_' . $groupnumber;
         $filearea = sprintf('feedback_files_%d_%d', $catscaleid, $groupnumber);
 
@@ -329,7 +331,7 @@ class customscalefeedback extends feedbackgenerator {
         return file_rewrite_pluginfile_urls(
             $content,
             'pluginfile.php',
-            $systemcontext->id,
+            $context->id,
             'local_catquiz',
             $filearea,
             $this->testid

--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -313,8 +313,9 @@ class customscalefeedback extends feedbackgenerator {
      * @return ?string
      */
     private function getfeedbackforrange(int $catscaleid, int $groupnumber, array $quizsettings): ?string {
-        $cm = get_coursemodule_from_instance('adaptivequiz', $this->testid);
-        $context = context_module::instance($cm->id);
+        if ($cm = get_coursemodule_from_instance('adaptivequiz', $this->testid)) {
+            $context = context_module::instance($cm->id);
+        }
         $quizsettingskey = 'feedbackeditor_scaleid_' . $catscaleid . '_' . $groupnumber;
         $filearea = sprintf('feedback_files_%d_%d', $catscaleid, $groupnumber);
 
@@ -328,14 +329,17 @@ class customscalefeedback extends feedbackgenerator {
             $content = $content->text;
         }
 
-        return file_rewrite_pluginfile_urls(
-            $content,
-            'pluginfile.php',
-            $context->id,
-            'local_catquiz',
-            $filearea,
-            $this->testid
-        );
+        if ($cm) {
+            return file_rewrite_pluginfile_urls(
+                $content,
+                'pluginfile.php',
+                $context->id,
+                'local_catquiz',
+                $filearea,
+                $this->testid
+            );
+        }
 
+        return $content;
     }
 }

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -505,6 +505,7 @@ $string['personabilityfeedbacktitle'] = 'Fähigkeitsprofil';
 $string['personabilityinscale'] = 'Fähigkeits-Wert für Skala „{$a}“';
 $string['personabilityrangestring'] = '{$a->rangestart} - {$a->rangeend}';
 $string['personabilitytitletab'] = 'Ergebnis-Details';
+$string['picturesavewarning'] = 'Im Moment werden Bilder in Feedbacks nur gespeichert, wenn ein bestehendes Quiz upgedated wird';
 $string['pilot_questions'] = 'Pilotfragen';
 $string['pilotratio'] = 'Anteil zu pilotierender Fragen in %';
 $string['pilotratio_help'] = 'Anteil von noch zu pilotierender Fragen an der Gesamtfragezahl in einem Test-Versuch. Die Angabe 20% führt beispielsweise dazu, dass eine von fünf Fragen  eines Test-Versuches eine zu pilotierende Frage sein wird.';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -486,6 +486,7 @@ $string['personabilityfeedbacktitle'] = 'Personability Profile';
 $string['personabilityinscale'] = 'Ability score in scale “{$a}”';
 $string['personabilityrangestring'] = '{$a->rangestart} - {$a->rangeend}';
 $string['personabilitytitletab'] = 'Details of results';
+$string['picturesavewarning'] = 'At the moment, pictures in feedbacks are only saved when an existing quiz is being edited';
 $string['pilot_questions'] = 'Pilot questions';
 $string['pilotratio'] = 'Proportion of questions to be piloted in %';
 $string['pilotratio_help'] = 'Proportion of questions still to be piloted in the total number of questions in a test attempt. For example, specifying 20% ​means that one out of five questions in a test experiment will be a question to be piloted';


### PR DESCRIPTION
Images are loaded into the draft area and displayed in the html forms. They are also displayed in shortcodes and the quiz feedback.

Note: when a quiz is saved for the first time, we do not have access to the context module at the time when we want to save the iamges. This means, that at the moment, images are only saved to the database when an existing quiz is updated, but not when a quiz is first created. We show a warning box to inform users about that.