### PR TITLE
Reduce github actions

### DIFF
--- a/.github/workflows/moodle-plugin-ci-pullreq.yml
+++ b/.github/workflows/moodle-plugin-ci-pullreq.yml
@@ -3,7 +3,8 @@ name: Moodle Plugin CI Pull Request
 on: 
   push:
     tags:
-      - '*'
+      - '[0-9]+' # Date tags
+      - '[0-9]+.[0-9]+.[0-9]+' # Version tags
   pull_request:
 
 jobs:

--- a/.github/workflows/moodle-plugin-ci-pullreq.yml
+++ b/.github/workflows/moodle-plugin-ci-pullreq.yml
@@ -1,0 +1,165 @@
+name: Moodle Plugin CI Pull Request
+
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      mariadb:
+        image: mariadb:10.8
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: 8.2
+            moodle-branch: MOODLE_404_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_404_STABLE
+            database: mariadb
+          - php: 8.2
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
+          - php: 7.4
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 7.4
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          # Install nvm v0.39.7 (temp workaround for issue moodlehq/moodle-plugin-ci#309).
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_wunderbyte_table
+          moodle-plugin-ci add-plugin --branch catmodel_main Wunderbyte-GmbH/moodle-mod_adaptivequiz
+          moodle-plugin-ci add-plugin --branch master branchup/moodle-filter_shortcodes
+          moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-adaptivequizcatmodel_catquiz
+
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+          MUSTACHE_IGNORE_NAMES: 'feedbackform_collapsible_close.mustache,feedbackform_collapsible_open.mustache,catscaleshortcodetablechildren.mustache'
+
+      - name: PHP Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci phplint
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpcpd
+
+      - name: PHP Mess Detector
+        continue-on-error: true # This step will show errors but will not fail
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpmd
+
+      - name: Moodle Code Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci codechecker --max-warnings 0
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpdoc
+
+      - name: Validating
+        if: ${{ always() }}
+        run: moodle-plugin-ci validate
+
+      - name: Check upgrade savepoints
+        if: ${{ always() }}
+        run: moodle-plugin-ci savepoints
+
+      - name: Mustache Lint
+        if: ${{ always() }}
+        run: moodle-plugin-ci mustache
+
+      - name: Grunt
+        if: ${{ always() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --testdox
+
+      - name: Behat features
+        if: ${{ always() }}
+        run: moodle-plugin-ci behat --profile chrome

--- a/.github/workflows/moodle-plugin-ci-pullreq.yml
+++ b/.github/workflows/moodle-plugin-ci-pullreq.yml
@@ -1,6 +1,10 @@
 name: Moodle Plugin CI Pull Request
 
-on: pull_request
+on: 
+  push:
+    tags:
+      - '*'
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/moodle-plugin-ci-push.yml
+++ b/.github/workflows/moodle-plugin-ci-push.yml
@@ -1,9 +1,7 @@
 name: Moodle Plugin CI Push
 
-on: 
-  push:
-    tags-ignore:
-      - '*'
+on: push
+
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/moodle-plugin-ci-push.yml
+++ b/.github/workflows/moodle-plugin-ci-push.yml
@@ -1,7 +1,9 @@
 name: Moodle Plugin CI Push
 
-on: push
-
+on: 
+  push:
+    tags-ignore:
+      - '*'
 jobs:
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/moodle-plugin-ci-push.yml
+++ b/.github/workflows/moodle-plugin-ci-push.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         include:
           - php: 8.2
-            moodle-branch: MOODLE_403_STABLE
+            moodle-branch: MOODLE_404_STABLE
             database: pgsql
           - php: 8.2
-            moodle-branch: MOODLE_403_STABLE
+            moodle-branch: MOODLE_404_STABLE
             database: mariadb
           - php: 7.4
             moodle-branch: MOODLE_401_STABLE

--- a/.github/workflows/moodle-plugin-ci-push.yml
+++ b/.github/workflows/moodle-plugin-ci-push.yml
@@ -1,6 +1,6 @@
-name: Moodle Plugin CI
+name: Moodle Plugin CI Push
 
-on: [push, pull_request]
+on: push
 
 jobs:
   test:
@@ -29,52 +29,10 @@ jobs:
       matrix:
         include:
           - php: 8.2
-            moodle-branch: MOODLE_404_STABLE
-            database: pgsql
-          - php: 8.2
-            moodle-branch: MOODLE_404_STABLE
-            database: mariadb
-          - php: 8.2
             moodle-branch: MOODLE_403_STABLE
             database: pgsql
           - php: 8.2
             moodle-branch: MOODLE_403_STABLE
-            database: mariadb
-          - php: 8.1
-            moodle-branch: MOODLE_403_STABLE
-            database: pgsql
-          - php: 8.1
-            moodle-branch: MOODLE_403_STABLE
-            database: mariadb
-          - php: 8.0
-            moodle-branch: MOODLE_403_STABLE
-            database: pgsql
-          - php: 8.0
-            moodle-branch: MOODLE_403_STABLE
-            database: mariadb
-          - php: 8.1
-            moodle-branch: MOODLE_402_STABLE
-            database: pgsql
-          - php: 8.1
-            moodle-branch: MOODLE_402_STABLE
-            database: mariadb
-          - php: 8.0
-            moodle-branch: MOODLE_402_STABLE
-            database: pgsql
-          - php: 8.0
-            moodle-branch: MOODLE_402_STABLE
-            database: mariadb
-          - php: 8.1
-            moodle-branch: MOODLE_401_STABLE
-            database: pgsql
-          - php: 8.1
-            moodle-branch: MOODLE_401_STABLE
-            database: mariadb
-          - php: 8.0
-            moodle-branch: MOODLE_401_STABLE
-            database: pgsql
-          - php: 8.0
-            moodle-branch: MOODLE_401_STABLE
             database: mariadb
           - php: 7.4
             moodle-branch: MOODLE_401_STABLE
@@ -103,8 +61,7 @@ jobs:
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8
-          # Install nvm v0.39.7 (temp workaround for issue moodlehq/moodle-plugin-ci#309).
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
       - name: Install moodle-plugin-ci
         run: |
           moodle-plugin-ci add-plugin --branch main Wunderbyte-GmbH/moodle-local_wunderbyte_table

--- a/tests/behat/catquestions_model_override.feature
+++ b/tests/behat/catquestions_model_override.feature
@@ -55,7 +55,6 @@ Feature: As an admin I perfrom model settings customizations over an imported of
     And I set the field "2PL Rasch-Birnbaum model" to "Calculated"
     And the "override_raschbirnbaum[override_raschbirnbaum_difficulty]" "field" should be disabled
     And the "override_raschbirnbaum[override_raschbirnbaum_discrimination]" "field" should be disabled
-    ## And I wait "31" seconds
     And I click on "Save changes" "button" in the "#lcq_model_override_form" "css_element"
     And I reload the page
     And I wait "1" seconds
@@ -80,4 +79,3 @@ Feature: As an admin I perfrom model settings customizations over an imported of
     And I reload the page
     And I should see "Manually confirmed" in the ".tab-model-status" "css_element"
     And I should see "3PL mixed Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
-    ## And I wait "31" seconds

--- a/tests/behat/catquestions_model_override.feature
+++ b/tests/behat/catquestions_model_override.feature
@@ -44,8 +44,8 @@ Feature: As an admin I perfrom model settings customizations over an imported of
       | 3PL mixed Rasch-Birnbaum model | Not yet calculated |
       | 1PL Rasch model                | Not yet calculated |
       | 2PL Rasch-Birnbaum model       | Manually updated   |
-      | override_raschbirnbaum[override_raschbirnbaum_difficulty]     | 1.36 |
-      | override_raschbirnbaum[override_raschbirnbaum_discrimination] | 0.31 |
+      | override_raschbirnbaum[override_raschbirnbaum_difficulty]     | 1.3600 |
+      | override_raschbirnbaum[override_raschbirnbaum_discrimination] | 0.3100 |
     And I should see "Manually updated" in the ".tab-model-status" "css_element"
     And I should see "2PL Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
     ## Verify hidden elements in case of "Not yet calculated" settings
@@ -55,27 +55,9 @@ Feature: As an admin I perfrom model settings customizations over an imported of
     And I set the field "2PL Rasch-Birnbaum model" to "Calculated"
     And the "override_raschbirnbaum[override_raschbirnbaum_difficulty]" "field" should be disabled
     And the "override_raschbirnbaum[override_raschbirnbaum_discrimination]" "field" should be disabled
+    ## And I wait "31" seconds
     And I click on "Save changes" "button" in the "#lcq_model_override_form" "css_element"
     And I reload the page
     And I wait "1" seconds
     And I should see "Calculated" in the ".tab-model-status" "css_element"
     And I should see "2PL Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
-    And I click on "Edit" "button" in the "#lcq_model_override_form" "css_element"
-    And I set the following fields to these values:
-      | 2PL Rasch-Birnbaum model       | Manually excluded |
-    And I click on "Save changes" "button" in the "#lcq_model_override_form" "css_element"
-    And I wait "1" seconds
-    And I reload the page
-    And I should see "Manually excluded" in the ".tab-model-status" "css_element"
-    And I should see "2PL Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
-    And I wait "1" seconds
-    And I click on "Edit" "button" in the "#lcq_model_override_form" "css_element"
-    And I set the following fields to these values:
-      | 3PL mixed Rasch-Birnbaum model | Manually confirmed |
-      | override_mixedraschbirnbaum[override_mixedraschbirnbaum_difficulty]     | 2.51 |
-      | override_mixedraschbirnbaum[override_mixedraschbirnbaum_discrimination] | 1.61 |
-      | override_mixedraschbirnbaum[override_mixedraschbirnbaum_guessing]       | 0.41 |
-    And I click on "Save changes" "button" in the "#lcq_model_override_form" "css_element"
-    And I reload the page
-    And I should see "Manually confirmed" in the ".tab-model-status" "css_element"
-    And I should see "3PL mixed Rasch-Birnbaum model" in the ".tab-model-status" "css_element"

--- a/tests/behat/catquestions_model_override.feature
+++ b/tests/behat/catquestions_model_override.feature
@@ -44,8 +44,8 @@ Feature: As an admin I perfrom model settings customizations over an imported of
       | 3PL mixed Rasch-Birnbaum model | Not yet calculated |
       | 1PL Rasch model                | Not yet calculated |
       | 2PL Rasch-Birnbaum model       | Manually updated   |
-      | override_raschbirnbaum[override_raschbirnbaum_difficulty]     | 1.3600 |
-      | override_raschbirnbaum[override_raschbirnbaum_discrimination] | 0.3100 |
+      | override_raschbirnbaum[override_raschbirnbaum_difficulty]     | 1.36 |
+      | override_raschbirnbaum[override_raschbirnbaum_discrimination] | 0.31 |
     And I should see "Manually updated" in the ".tab-model-status" "css_element"
     And I should see "2PL Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
     ## Verify hidden elements in case of "Not yet calculated" settings
@@ -61,3 +61,23 @@ Feature: As an admin I perfrom model settings customizations over an imported of
     And I wait "1" seconds
     And I should see "Calculated" in the ".tab-model-status" "css_element"
     And I should see "2PL Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
+    And I click on "Edit" "button" in the "#lcq_model_override_form" "css_element"
+    And I set the following fields to these values:
+      | 2PL Rasch-Birnbaum model       | Manually excluded |
+    And I click on "Save changes" "button" in the "#lcq_model_override_form" "css_element"
+    And I wait "1" seconds
+    And I reload the page
+    And I should see "Manually excluded" in the ".tab-model-status" "css_element"
+    And I should see "2PL Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
+    And I wait "1" seconds
+    And I click on "Edit" "button" in the "#lcq_model_override_form" "css_element"
+    And I set the following fields to these values:
+      | 3PL mixed Rasch-Birnbaum model | Manually confirmed |
+      | override_mixedraschbirnbaum[override_mixedraschbirnbaum_difficulty]     | 2.51 |
+      | override_mixedraschbirnbaum[override_mixedraschbirnbaum_discrimination] | 1.61 |
+      | override_mixedraschbirnbaum[override_mixedraschbirnbaum_guessing]       | 0.41 |
+    And I click on "Save changes" "button" in the "#lcq_model_override_form" "css_element"
+    And I reload the page
+    And I should see "Manually confirmed" in the ".tab-model-status" "css_element"
+    And I should see "3PL mixed Rasch-Birnbaum model" in the ".tab-model-status" "css_element"
+    ## And I wait "31" seconds


### PR DESCRIPTION
On pushes, the matrix is smaller (two PHP versions, 7.4 and 8.2, on two moodle version, 4.1 and 4.4.
On pull requests and tag pushes (version tags x.y.z or date tags like e.g. 202401010100), the test matrix is the same as before.