### PR TITLE
GH-720 Fix import error with multiple question versions

### DIFF
--- a/classes/local/model/model_item_param_list.php
+++ b/classes/local/model/model_item_param_list.php
@@ -430,15 +430,16 @@ class model_item_param_list implements ArrayAccess, IteratorAggregate, Countable
                 $new = array_pop($records);
 
                 // 1. Remove old question versions from scale:
-                foreach ($records as $r) {
-                    $catscale = $DB->get_record('local_catquiz_catscales', ['name' => $newrecord['catscalename']]);
-                    catscale::remove_testitem_from_scale($catscale->id, $r->questionid);
+                if ($catscale = $DB->get_record('local_catquiz_catscales', ['name' => $newrecord['catscalename']])) {
+                    foreach ($records as $r) {
+                        catscale::remove_testitem_from_scale($catscale->id, $r->questionid);
+                    }
+                    $newrecord['warning'] = 'Removed older question versions from scale';
                 }
 
                 // 2. Continue with the most recent version of the question:
                 unset($newrecord['label']);
                 $newrecord['componentid'] = $new->questionid;
-                $newrecord['warning'] = 'Removed older question versions from scale';
                 $returnarray = self::save_or_update_testitem_in_db($newrecord);
                 return $returnarray;
             }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_catquiz';
 $plugin->release = '1.1.0';
-$plugin->version = 2024101600;
+$plugin->version = 2024102400;
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
This makes the code more robust: If there exist multiple question versions, we try to remove older question versions from the scale it should be assigned to. However, it is possible that the scale it should be assigned to does not exist yet. This is accounted for in the updated code.