### PR TITLE
Update lasttimeplayedpenalty.php

### DIFF
--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -107,6 +107,6 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
         // Do all calculations in days.
         $timedifference = ($lastplayed - $currenttime) * self::SECONDS_TO_DAYS;
 
-        return 1 / (1 + exp(self::EXP_FACTOR / ($penaltytimerange) * ($timedifference + $penaltytimerange)));
+        return 1 / (1 + exp(self::EXP_FACTOR / $penaltytimerange * ($timedifference + $penaltytimerange)));
     }
 }

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -96,7 +96,7 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
      *
      * @return float
      */
-    public function get_penalty_factor($question, int $currenttime, float $penaltytimerange): float {
+    public function get_penalty_factor(stdClass $question, int $currenttime, float $penaltytimerange): float {
         $lastplayed = $question->userlastattempttime;
         $timedifference = ($lastplayed - $currenttime);
 

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -105,9 +105,9 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
         $lastplayed = $question->userlastattempttime;
 
         // Do all calculations in days.
-        $timedifference = ($lastplayed - $currenttime) * self::SECONDS_TO_DAYS;
-        $penaltytimerange = $penaltytimerange * self::SECONDS_TO_DAYS;
-        
+        $timedifference = ($lastplayed - $currenttime);
+        $penaltytimerange = $penaltytimerange;
+
         return 1 / (1 + exp(self::EXP_FACTOR / $penaltytimerange * ($timedifference + $penaltytimerange)));
     }
 }

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -98,8 +98,6 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
      */
     public function get_penalty_factor($question, int $currenttime, float $penaltytimerange): float {
         $lastplayed = $question->userlastattempttime;
-
-        // Do all calculations in days.
         $timedifference = ($lastplayed - $currenttime);
 
         return 1 / (1 + exp(self::EXP_FACTOR / $penaltytimerange * ($timedifference + $penaltytimerange)));

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -41,7 +41,7 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
     /**
      * This is used as factor in the exp function
      *
-     * The value of 4.6 (ln(99)) should ensure that after 10% of the penalty
+     * The value of ln(99) / 0.9 should ensure that after 10% of the penalty
      * timerange has passed, the resulting probability exceeds 0.01.
      *
      * Assuming a timerange of 10 days, the weight factor will be as follows:
@@ -51,7 +51,12 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
      *
      * @see https://github.com/Wunderbyte-GmbH/moodle-local_catquiz/issues/424#issuecomment-2092820159
      */
-    const EXP_FACTOR = 4.6;
+    const EXP_FACTOR = 5.1056887223718;
+
+    /**
+     * Factor for getting unix timestamp (seconds) in days.
+     */
+    const SECONDS_TO_DAYS = 1 / (60 * 60 * 24);
 
     /**
      * Run preselect task.
@@ -98,6 +103,10 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
      */
     public function get_penalty_factor($question, int $currenttime, float $penaltytimerange): float {
         $lastplayed = $question->userlastattempttime;
-        return 1 / (1 + exp(self::EXP_FACTOR * (1 - ($currenttime - $lastplayed) / $penaltytimerange)));
+
+        // Do all calculations in days.
+        $timedifference = ($lastplayed - $currenttime) * self::SECONDS_TO_DAYS;
+
+        return 1 / (1 + exp(self::EXP_FACTOR / ($penaltytimerange) * ($timedifference + $penaltytimerange)));
     }
 }

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -54,11 +54,6 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
     const EXP_FACTOR = 5.1056887223718;
 
     /**
-     * Factor for getting unix timestamp (seconds) in days.
-     */
-    const SECONDS_TO_DAYS = 1 / (60 * 60 * 24);
-
-    /**
      * Run preselect task.
      *
      * @param array $context

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -101,7 +101,6 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
 
         // Do all calculations in days.
         $timedifference = ($lastplayed - $currenttime);
-        $penaltytimerange = $penaltytimerange;
 
         return 1 / (1 + exp(self::EXP_FACTOR / $penaltytimerange * ($timedifference + $penaltytimerange)));
     }

--- a/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
+++ b/classes/teststrategy/preselect_task/lasttimeplayedpenalty.php
@@ -106,7 +106,8 @@ final class lasttimeplayedpenalty extends preselect_task implements wb_middlewar
 
         // Do all calculations in days.
         $timedifference = ($lastplayed - $currenttime) * self::SECONDS_TO_DAYS;
-
+        $penaltytimerange = $penaltytimerange * self::SECONDS_TO_DAYS;
+        
         return 1 / (1 + exp(self::EXP_FACTOR / $penaltytimerange * ($timedifference + $penaltytimerange)));
     }
 }

--- a/tests/teststrategy/preselect_task/lasttimeplayedpenalty_test.php
+++ b/tests/teststrategy/preselect_task/lasttimeplayedpenalty_test.php
@@ -1,0 +1,100 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests the lasttimeplayedpenalty class
+ *
+ * @package    local_catquiz
+ * @author David Szkiba <david.szkiba@wunderbyte.at>
+ * @copyright  2024 Georg Maißer <info@wunderbyte.at>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_catquiz\teststrategy\preselect_task;
+
+use local_catquiz\teststrategy\preselect_task\lasttimeplayedpenalty;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the lasttimeplayedpenalty class
+ *
+ * @package    local_catquiz
+ * @author David Szkiba <david.szkiba@wunderbyte.at>
+ * @copyright  2024 Georg Maißer <info@wunderbyte.at>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \local_catquiz\teststrategy\preselect_task\lasttimeplayedpenalty
+ */
+final class lasttimeplayedpenalty_test extends TestCase {
+
+    /**
+     * @var int
+     *
+     * Use 1 day as default timerange
+     */
+    const TIMERANGE = 60 * 60 * 24;
+
+    /**
+     * Checks that the penalty is calculated correctly
+     *
+     * @param float $expected
+     * @param \stdClass $question
+     * @param int $currenttime
+     * @param float $penaltytimerange
+     * @return void
+     * @dataProvider penalty_is_calculated_correctly_provider
+     */
+    public function test_penalty_is_calculated_correctly(
+        float $expected,
+        \stdClass $question,
+        int $currenttime,
+        float $penaltytimerange
+    ): void {
+        $lasttimeplayedpenalty = new lasttimeplayedpenalty();
+        $penalty = $lasttimeplayedpenalty->get_penalty_factor($question, $currenttime, $penaltytimerange);
+        $this->assertEqualsWithDelta($expected, $penalty, 0.000001);
+    }
+
+    /**
+     * Dataprovider for the penalty test.
+     *
+     * @return array
+     */
+    public static function penalty_is_calculated_correctly_provider(): array {
+        $now = time();
+        return [
+            'Penalty is 0.01 if 10% of timerange has passed' => [
+                    'expected' => 0.01,
+                    'question' => (object) ['userlastattempttime' => $now - 0.1 * self::TIMERANGE],
+                    'currenttime' => $now,
+                    'penaltytimerange' => self::TIMERANGE,
+            ],
+            'Penalty is 0.5 if no time has passed' => [
+                    'expected' => 0.5,
+                    'question' => (object) ['userlastattempttime' => $now - self::TIMERANGE],
+                    'currenttime' => $now,
+                    'penaltytimerange' => self::TIMERANGE,
+            ],
+            'Penalty is 0.99 if 190% of timerange has passed' => [
+                    'expected' => 0.99,
+                    'question' => (object) ['userlastattempttime' => $now - 1.9 * self::TIMERANGE],
+                    'currenttime' => $now,
+                    'penaltytimerange' => self::TIMERANGE,
+            ],
+        ];
+    }
+}
+


### PR DESCRIPTION
Fixed:
* const 
* formula

assuming that until now, time varibles $lastplayed and $currentime are in unix timestamp (in seconds), however $penaltytimerange is given in days. So, all calculation is now done in days.

Please further check:
- [ ] are these asumptions correct?
- [ ] does the new formula fulfil the given 1% at 10% of the time passing-rule
- [ ] when giving $penaltytimerange, is the plugin's setting been used or is it still fixed coded?