### PR TITLE
GH-706 Update get_difficulty() for multiparam models

### DIFF
--- a/catmodel/grm/classes/grm.php
+++ b/catmodel/grm/classes/grm.php
@@ -155,6 +155,16 @@ class grm extends model_multiparam {
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @param array $parameters
+     * @return float
+     */
+    public static function get_difficulty(array $parameters): float {
+        return self::calculate_mean_difficulty($parameters);
+    }
+
+    /**
      * Calculate the mean difficulty
      *
      * @param array $ip

--- a/catmodel/grmgeneralized/classes/grmgeneralized.php
+++ b/catmodel/grmgeneralized/classes/grmgeneralized.php
@@ -139,7 +139,7 @@ class grmgeneralized extends model_multiparam {
      */
     public static function add_parameters_to_record(stdClass $record, array $parameters): stdClass {
         $record->json = json_encode(['difficulties' => $parameters['difficulties']]);
-        $record->difficulty = $record->difficulty ?? self::get_difficulty_aggregate((object) $parameters);
+        $record->difficulty = $record->difficulty ?? self::calculate_mean_difficulty($parameters);
         return $record;
     }
 
@@ -150,17 +150,7 @@ class grmgeneralized extends model_multiparam {
      * @return float
      */
     public static function get_difficulty(array $parameters): float {
-        return self::get_difficulty_aggregate((object) $parameters);
-    }
-
-    /**
-     * Return a single float value for the difficulty.
-     *
-     * @param stdClass $record
-     * @return float
-     */
-    private static function get_difficulty_aggregate(stdClass $record) {
-        return $record->difficulties['1.00'];
+        return self::calculate_mean_difficulty($parameters);
     }
 
     /**

--- a/catmodel/pcm/classes/pcm.php
+++ b/catmodel/pcm/classes/pcm.php
@@ -43,6 +43,16 @@ use stdClass;
 class pcm extends model_multiparam {
 
     /**
+     * {@inheritDoc}
+     *
+     * @param array $parameters
+     * @return float
+     */
+    public static function get_difficulty(array $parameters): float {
+        return self::calculate_mean_difficulty($parameters);
+    }
+
+    /**
      * Returns the item parameter array from a database record.
      *
      * @param stdClass $record

--- a/catmodel/pcmgeneralized/classes/pcmgeneralized.php
+++ b/catmodel/pcmgeneralized/classes/pcmgeneralized.php
@@ -55,6 +55,16 @@ class pcmgeneralized extends model_multiparam {
     /**
      * {@inheritDoc}
      *
+     * @param array $parameters
+     * @return float
+     */
+    public static function get_difficulty(array $parameters): float {
+        return self::calculate_mean_difficulty($parameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @param stdClass $record
      * @return array
      */


### PR DESCRIPTION
In multiparam models, `get_difficulty()` will return the value of `calculate_mean_difficulty()`.

Closes #706 