### PR TITLE
GH-760 Fix possibly undeclared variable

### DIFF
--- a/classes/teststrategy/feedbackgenerator.php
+++ b/classes/teststrategy/feedbackgenerator.php
@@ -396,6 +396,7 @@ abstract class feedbackgenerator {
         );
 
         $personabilities = [];
+        $selectedscaleid = null;
         // Ability range is the same for all scales with same root scale.
         $abiltiyrange = $this->feedbackhelper->get_ability_range(array_key_first($catscales));
         foreach ($personabilitiesfeedbackeditor as $catscale => $personability) {


### PR DESCRIPTION
Closes #760 

It is possible, that `$selectedscaleid` is never assigned a value. In order for it to still be declared, it is initialized to `null`.