### PR TITLE
GH-762 Show message if default context is missing

### DIFF
--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -243,6 +243,8 @@ $string['debuginfo_desc'] = 'Hier können Sie als Nutzer mit Berechtigung zum Do
 $string['debuginfo_desc_title'] = 'Export des Testversuchs Nr. {$a}';
 $string['defaultcontext'] = 'Neuer Standard Einsatz-Kontext für Skala';
 $string['defaultcontextdescription'] = 'Beinhaltet alle Testitems';
+$string['defaultcontextmissing'] = 'Es konnte kein Standard Kontext in der Datenbank gefunden werden. Bitte gehen Sie sicher, dass '
+    . 'der Installationsprozess erfolgreich abgeschlossen wurde.';
 $string['defaultcontextname'] = 'Standard Kontext';
 $string['defaultdateformat'] = 'j.n.Y H:i:s';
 $string['deletedatatitle'] = 'Löschen';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -241,6 +241,8 @@ $string['debuginfo_desc'] = 'As a user with permission to export attempts, you c
 $string['debuginfo_desc_title'] = 'Export attempt # {$a}';
 $string['defaultcontext'] = 'New default context for scale';
 $string['defaultcontextdescription'] = 'Includes all test items';
+$string['defaultcontextmissing'] = 'The default context is missing from the database. Please make sure the installation process '
+    . 'completed successfully.';
 $string['defaultcontextname'] = 'Default CAT context';
 $string['defaultdateformat'] = 'j.n.Y H:i:s';
 $string['deletedatatitle'] = 'Delete';

--- a/manage_catscales.php
+++ b/manage_catscales.php
@@ -22,6 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\notification;
 use local_catquiz\catquiz;
 use local_catquiz\catscale;
 use local_catquiz\output\catscalemanager\managecatscaledashboard;
@@ -39,9 +40,6 @@ $componentname = optional_param('component', 'question', PARAM_TEXT);
 
 if ($catscale != -1 && empty($catcontextid)) {
     $catcontextid = catscale::get_context_id($catscale);
-}
-if (empty($catcontextid)) {
-    $catcontextid = catquiz::get_default_context_id();
 }
 
 if ($catscale != -1) {
@@ -62,6 +60,16 @@ $PAGE->set_title($title);
 $PAGE->set_heading($title);
 
 echo $OUTPUT->header();
+
+if (empty($catcontextid)) {
+    try {
+        $catcontextid = catquiz::get_default_context_id();
+    } catch (dml_missing_record_exception $e) {
+        notification::warning(get_string('defaultcontextmissing', 'local_catquiz'));
+        echo $OUTPUT->footer();
+        return;
+    }
+}
 
 $managecatscaledashboard = new managecatscaledashboard(
     $testitemid,


### PR DESCRIPTION
There should actually always be a default context in the database. If it is missing, it indicates a problem with the installation. This shows a warning notification to inform the user to double-check that the installation process was completed successfully.