### PR TITLE
GH-719 statistics shortcode catches error for missing setting

### DIFF
--- a/classes/output/catquizstatistics.php
+++ b/classes/output/catquizstatistics.php
@@ -27,6 +27,7 @@ use local_catquiz\feedback\feedbackclass;
 use local_catquiz\local\model\model_strategy;
 use local_catquiz\teststrategy\feedback_helper;
 use local_catquiz\teststrategy\info;
+use LogicException;
 use moodle_url;
 use stdClass;
 
@@ -1099,15 +1100,21 @@ class catquizstatistics {
             $out .= $table;
         }
 
-        $colorbarlegend = false;
-        if ($this->get_quizsettings()) {
-            $legend = feedback_helper::get_colorbarlegend(
-                    $this->get_quizsettings(),
+        if ($qs = $this->get_quizsettings()) {
+            try {
+                $legend = feedback_helper::get_colorbarlegend(
+                    $qs,
                     $this->scaleid,
                     $this->check_quizsettings_are_compatible(self::COMPATIBILITY_LEVEL_DESCRIPTION),
                     true
                 );
-            $colorbarlegend = ['feedbackbarlegend' => $legend];
+                $colorbarlegend = ['feedbackbarlegend' => $legend];
+            } catch (LogicException $e) {
+                // We should have better validation for valid quiz settings.
+                // Until then, if the quizsettings don't have a range for the
+                // given scale, we don't show the legend.
+                $colorbarlegend = false;
+            }
         }
         return [
             'colorbarlegend' => $colorbarlegend,

--- a/classes/shortcodes.php
+++ b/classes/shortcodes.php
@@ -209,7 +209,14 @@ class shortcodes {
         $endtime = $args['endtime'] ?? null;
         $starttime = $args['starttime'] ?? null;
 
-        $heading = self::get_heading($courseid, $globalscale, $testid, $starttime, $endtime);
+        try {
+            $heading = self::get_heading($courseid, $globalscale, $testid, $starttime, $endtime);
+        } catch (\Exception $e) {
+            return $OUTPUT->render_from_template(
+                'local_catquiz/catscaleshortcodes/catscalestatistics',
+                ['error' => $e->getMessage()]
+            );
+        }
 
         try {
             $catquizstatistics = new catquizstatistics($courseid, $testid, $globalscale, $endtime, $starttime);

--- a/classes/teststrategy/feedback_helper.php
+++ b/classes/teststrategy/feedback_helper.php
@@ -28,6 +28,7 @@ use local_catquiz\catscale;
 use local_catquiz\feedback\feedbackclass;
 use local_catquiz\local\model\model_item_param;
 use local_catquiz\local\model\model_model;
+use LogicException;
 use stdClass;
 
 /**
@@ -432,6 +433,17 @@ class feedback_helper {
             $feedbacktextkey = 'feedbacklegend_scaleid_' . $catscaleid . '_' . $j;
             $lowerlimitkey = "feedback_scaleid_limit_lower_" . $catscaleid . "_" . $j;
             $upperlimitkey = "feedback_scaleid_limit_upper_" . $catscaleid . "_" . $j;
+
+            // It would probably be a good idea to define a class for $quizsettings.
+            // That way, we could more easily check if settings are valid or include a given CAT scale.
+            if (
+                !isset($quizsettings->$upperlimitkey)
+                || !isset($quizsettings->$lowerlimitkey)
+            ) {
+                throw new LogicException(
+                    'Trying to get feedback ranges for a CAT scale that is not configured in the given quizsettings'
+                );
+            }
 
             $feedbackrangestring = get_string(
                 'subfeedbackrange',


### PR DESCRIPTION
If we try to determine the range for a given scale in a quiz but those values do not exist, fallback to not displaying the range legend.