### PR TITLE
GH-767 Fix deletion of CAT contexts

### DIFF
--- a/classes/catcontext.php
+++ b/classes/catcontext.php
@@ -26,6 +26,7 @@
 namespace local_catquiz;
 
 use cache_helper;
+use dml_exception;
 use local_catquiz\event\context_created;
 use local_catquiz\event\context_updated;
 use local_catquiz\local\model\model_item_param_list;
@@ -382,5 +383,24 @@ class catcontext {
      */
     public function gettimecalculated(): int {
         return $this->timecalculated;
+    }
+
+    /**
+     * Delete a CAT context.
+     *
+     * @param int $id
+     *
+     * @return bool
+     *
+     */
+    public static function delete(int $id) {
+        global $DB;
+
+        try {
+            $DB->delete_records('local_catquiz_catcontext', ['id' => $id]);
+            return true;
+        } catch (dml_exception $e) {
+            return false;
+        }
     }
 }

--- a/classes/catcontext.php
+++ b/classes/catcontext.php
@@ -33,6 +33,7 @@ use local_catquiz\local\model\model_item_param_list;
 use local_catquiz\local\model\model_person_param_list;
 use local_catquiz\local\model\model_responses;
 use local_catquiz\local\model\model_strategy;
+use moodle_exception;
 use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
@@ -391,16 +392,21 @@ class catcontext {
      * @param int $id
      *
      * @return bool
-     *
+     * @throws moodle_exception
      */
     public static function delete(int $id) {
         global $DB;
 
+        // The default context should never be deleted.
+        $defaultcontextid = catquiz::get_default_context_id();
+        if ($id == $defaultcontextid) {
+            throw new moodle_exception('cannotdeletedefaultcontext', 'local_catquiz');
+        }
+
         try {
             $DB->delete_records('local_catquiz_catcontext', ['id' => $id]);
-            return true;
         } catch (dml_exception $e) {
-            return false;
+            throw new moodle_exception('error');
         }
     }
 }

--- a/classes/table/catcontext_table.php
+++ b/classes/table/catcontext_table.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 
 use cache_helper;
+use Exception;
 use local_catquiz\catcontext;
 use local_catquiz\testenvironment;
 use local_wunderbyte_table\wunderbyte_table;
@@ -192,15 +193,15 @@ class catcontext_table extends wunderbyte_table {
      */
     public function action_deleteitem(int $id, string $data): array {
 
-        if (catcontext::delete($id)) {
-            $success = 1;
+        try {
+            catcontext::delete($id);
             $message = get_string('success');
-        } else {
-            $success = 0;
-            $message = get_string('error');
+            $success = true;
+            cache_helper::purge_by_event('changesincatcontexts');
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+            $success = false;
         }
-
-        cache_helper::purge_by_event('changesincatcontexts');
 
         return [
             'success' => $success,

--- a/classes/table/catcontext_table.php
+++ b/classes/table/catcontext_table.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 global $CFG;
 
 use cache_helper;
+use local_catquiz\catcontext;
 use local_catquiz\testenvironment;
 use local_wunderbyte_table\wunderbyte_table;
 use stdClass;
@@ -191,7 +192,7 @@ class catcontext_table extends wunderbyte_table {
      */
     public function action_deleteitem(int $id, string $data): array {
 
-        if (testenvironment::delete_testenvironment($id)) {
+        if (catcontext::delete($id)) {
             $success = 1;
             $message = get_string('success');
         } else {
@@ -199,7 +200,7 @@ class catcontext_table extends wunderbyte_table {
             $message = get_string('error');
         }
 
-        cache_helper::purge_by_event('changesintestenvironments');
+        cache_helper::purge_by_event('changesincatcontexts');
 
         return [
             'success' => $success,

--- a/lang/de/local_catquiz.php
+++ b/lang/de/local_catquiz.php
@@ -98,6 +98,7 @@ $string['callbackfunctionnotapplied'] = 'Callback Funktion konnte nicht angewand
 $string['callbackfunctionnotdefined'] = 'Callback Funktion nicht definiert.';
 $string['canbesetto0iflabelgiven'] = 'Kann 0 sein, wenn Abgleich über Label stattfindet.';
 $string['cancelexpiredattempts'] = 'Abgelaufene Versuche schließen';
+$string['cannotdeletedefaultcontext'] = 'Der Default CAT Kontext kann nicht gelöscht werden';
 $string['cannotdeletescalewithchildren'] = 'Skalen mit Unterskalen können nicht gelöscht werden.';
 $string['catcatscaleprime'] = 'Inhaltsbereich (Globalskala)';
 $string['catcatscaleprime_help'] = 'Wählen Sie den für Sie relevanten Inhaltsbereich aus. Inhaltsbereche werden als CAT-Skala durch eine*n CAT-Manager*in angelegt und verwaltet. Falls Sie eigene Inhalts- und Unterbereiche wünschen, wenden Sie sich bitte an den oder die CAT-Manager*in oder den bzw. die Adminstrator*in Ihrer Moodle-Instanz.';

--- a/lang/en/local_catquiz.php
+++ b/lang/en/local_catquiz.php
@@ -98,6 +98,7 @@ $string['callbackfunctionnotapplied'] = 'Callback function could not be applied.
 $string['callbackfunctionnotdefined'] = 'Callback function is not defined.';
 $string['canbesetto0iflabelgiven'] = 'Can be 0 if matching of testitem is via label.';
 $string['cancelexpiredattempts'] = 'Cancel attempts exceeding maximum time';
+$string['cannotdeletedefaultcontext'] = 'Cannot delete default CAT context';
 $string['cannotdeletescalewithchildren'] = 'Cannot delete CAT scale with children';
 $string['catcatscaleprime'] = 'Content/Scale';
 $string['catcatscaleprime_help'] = 'Select the content area that is relevant to you. Content areas are created and managed as a so-called scale by a CAT manager. If you would like your own content and sub-areas, please contact the CAT manager or the administrator of your Moodle instance.';


### PR DESCRIPTION
This was probably a copy/paste error: the delete button tried to delete a testenvironment with the given ID, not a CAT context. This is fixed here.

Closes #767 