### PR TITLE
GH-792 Fix array offset

### DIFF
--- a/classes/teststrategy/feedbackgenerator/customscalefeedback.php
+++ b/classes/teststrategy/feedbackgenerator/customscalefeedback.php
@@ -247,7 +247,7 @@ class customscalefeedback extends feedbackgenerator {
         uksort($scalefeedback, function ($a, $b) use ($catscales) {
             $a = (object) $catscales[$a];
             $b = (object) $catscales[$b];
-            return $catscales[$a]->name <=> $catscales[$b]->name;
+            return $catscales[$a->id]->name <=> $catscales[$b->id]->name;
         });
         $sorted = $scalefeedback;
         if ($mainscale) {


### PR DESCRIPTION
A previous commit converted the entries of `$catscales` to objects. Therefore, we have to explicitely get the numeric ID with `$a->id` or `$b->id`.