### PR TITLE
Bugfix: Make sure first column in sql is unique #814

### DIFF
--- a/classes/catquiz.php
+++ b/classes/catquiz.php
@@ -2714,11 +2714,12 @@ SQL;
         // Get all contexts.
         $contexts = $DB->get_records_sql(
             <<<SQL
-                SELECT * FROM {local_catquiz_catscales} s
+                SELECT DISTINCT s.*
+                FROM {local_catquiz_catscales} s
                 JOIN {local_catquiz_catcontext} cc ON s.contextid = cc.id
                 WHERE s.contextid IS NOT NULL
-                  AND cc.starttimestamp <= :now1 AND cc.endtimestamp >= :now2
-                ;
+                AND cc.starttimestamp <= :now1 AND cc.endtimestamp >= :now2
+            ;
             SQL,
             [
                 'now1' => $now,


### PR DESCRIPTION
@ralferlebach mit meinen daten wird hier kein fehler geworfen. können wir uns vielleciht die daten bei dir in der db mal anschauen, woher die duplikate in der id der skala kommt, wenn man folgendes sql ausführt:
                SELECT * FROM m_local_catquiz_catscales s
                JOIN m_local_catquiz_catcontext cc ON s.contextid = cc.id
                SELECT s.id, MIN(cc.name) as example_column
                WHERE s.contextid IS NOT NULL;